### PR TITLE
Fix sample configuration file linting issues.

### DIFF
--- a/examples/jiralert.yml
+++ b/examples/jiralert.yml
@@ -1,3 +1,4 @@
+---
 # Global defaults, applied to all receivers where not explicitly overridden. Optional.
 defaults:
   # API access fields.
@@ -35,7 +36,7 @@ receivers:
     # Overrides default.
     issue_type: Task
     # JIRA components. Optional.
-    components: [ 'Operations' ]
+    components: ['Operations']
     # Standard or custom field values to set on created issue. Optional.
     #
     # See https://developer.atlassian.com/server/jira/platform/jira-rest-api-examples/#setting-custom-field-data-for-other-field-types for further examples.
@@ -43,9 +44,9 @@ receivers:
       # TextField
       customfield_10001: "Random text"
       # SelectList
-      customfield_10002: { "value": "red" }
+      customfield_10002: {"value": "red"}
       # MultiSelect
-      customfield_10003: [{"value": "red" }, {"value": "blue" }, {"value": "green" }]
+      customfield_10003: [{"value": "red"}, {"value": "blue"}, {"value": "green"}]
 
 # File containing template definitions. Required.
 template: jiralert.tmpl


### PR DESCRIPTION
Before:
```
$ yamllint-3 jiralert.yml
  2:1       warning  missing document start "---"  (document-start)
  38:18     error    too many spaces inside brackets  (brackets)
  38:31     error    too many spaces inside brackets  (brackets)
  46:27     error    too many spaces inside braces  (braces)
  46:42     error    too many spaces inside braces  (braces)
```

After:
```
$ yamllint-3 jiralert.yml
```