### PR TITLE
add client cert support

### DIFF
--- a/cmd/jiralert/main.go
+++ b/cmd/jiralert/main.go
@@ -194,17 +194,7 @@ func setupLogger(lvl string, fmt string) (logger log.Logger) {
 	return
 }
 
-// if KeyFile and CertFile are not specified, fall back to username/password
-// username/password and client certs are mutually exclusive
 func httpClient(conf *config.ReceiverConfig) (*http.Client, error) {
-	// if conf.KeyFile == "" && conf.CertFile == "" {
-	// 	hc := jira.BasicAuthTransport{
-	// 		Username: conf.User,
-	// 		Password: string(conf.Password),
-	// 	}
-	// 	return hc.Client(), nil
-	// }
-
 	tlsConfig, err := newTLSConfig(conf)
 	if err != nil {
 		return nil, err

--- a/examples/jiralert.yml
+++ b/examples/jiralert.yml
@@ -4,6 +4,10 @@ defaults:
   api_url: https://jiralert.atlassian.net
   user: jiralert
   password: 'JIRAlert'
+  # optional client cert
+  # cert_file: /path/to/cert.crt
+  # key_file: /path/to/cert.key
+  # insecure_skip_verify: false
 
   # The type of JIRA issue to create. Required.
   issue_type: Bug

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -94,9 +94,13 @@ type ReceiverConfig struct {
 	Name string `yaml:"name" json:"name"`
 
 	// API access fields
-	APIURL   string `yaml:"api_url" json:"api_url"`
-	User     string `yaml:"user" json:"user"`
-	Password Secret `yaml:"password" json:"password"`
+	APIURL             string `yaml:"api_url" json:"api_url"`
+	User               string `yaml:"user" json:"user"`
+	Password           Secret `yaml:"password" json:"password"`
+	CAFile             string `yaml:"ca_file" json:"ca_file"`
+	CertFile           string `yaml:"cert_file" json:"cert_file"`
+	KeyFile            string `yaml:"key_file" json:"key_file"`
+	InsecureSkipVerify bool   `yaml:"insecure_skip_verify" json:"insecure_skip_verify"`
 
 	// Required issue fields
 	Project     string `yaml:"project" json:"project"`
@@ -178,6 +182,8 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if _, err := url.Parse(rc.APIURL); err != nil {
 			return fmt.Errorf("invalid api_url %q in receiver %q: %s", rc.APIURL, rc.Name, err)
 		}
+		// user/password isn't technically required if using client cert
+		// auth, but will be ignored if set, so leaving this as required
 		if rc.User == "" {
 			if c.Defaults.User == "" {
 				return fmt.Errorf("missing user in receiver %q", rc.Name)
@@ -189,6 +195,25 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				return fmt.Errorf("missing password in receiver %q", rc.Name)
 			}
 			rc.Password = c.Defaults.Password
+		}
+
+		// want to be able to override CAFile/KeyFile/CertFile in each receiver
+		// while still having a default value - use "none" to indicate no value
+		// set
+		if rc.CAFile == "none" {
+			rc.CAFile = ""
+		} else if rc.CAFile == "" && c.Defaults.CAFile != "" {
+			rc.CAFile = c.Defaults.CAFile
+		}
+		if rc.CertFile == "none" {
+			rc.CertFile = ""
+		} else if rc.CertFile == "" && c.Defaults.CertFile != "" {
+			rc.CertFile = c.Defaults.CertFile
+		}
+		if rc.KeyFile == "none" {
+			rc.KeyFile = ""
+		} else if rc.KeyFile == "" && c.Defaults.KeyFile != "" {
+			rc.KeyFile = c.Defaults.KeyFile
 		}
 
 		// Check required issue fields


### PR DESCRIPTION
This adds the ability to specify client certificates to use when talking to Jira - depending on the config, that may be sufficient to identify the account creating the Jira issues.

I left user/password as required - in the case where the client cert is used for authentication, they'll often just be ignored (depends on server config).

- I didn't see a clean way to unset user_cert/user_key in the individual receivers if set in the default, so I made the value of 'none' magical.  I'm open to any better suggestions.

- what's the correct way to set insecure_skip_verify boolean based on the default?  As-is, you'd have to specify it per receiver.