### PR TITLE
Update circleci/golang version from 1.12 to 1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     docker:
       # Available from https://hub.docker.com/r/circleci/golang/
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.14
     working_directory: /go/src/github.com/prometheus-community/jiralert
     environment:
       GO111MODULE: 'on'

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,5 +1,5 @@
 go:
-    version: 1.13
+    version: 1.14
 repository:
     path: github.com/prometheus-community/jiralert
 build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/golang:1.12 AS builder
+FROM circleci/golang:1.14 AS builder
 COPY . /go/src/github.com/prometheus-community/jiralert
 RUN mkdir -p /go/src/github.com/prometheus-community/jiralert && sudo chown -R circleci:circleci /go/src/github.com/prometheus-community/
 WORKDIR /go/src/github.com/prometheus-community/jiralert


### PR DESCRIPTION
HI.
I have updated `circleci/golang` version in the Dockerfile.

I checked go.mod and found that it is developing using 1.14, so I specify this version.

https://github.com/prometheus-community/jiralert/commit/f7b8dc28f12bb3b0abf158f648e145088a215eb2