### PR TITLE
error if http method for home or config is not GET

### DIFF
--- a/cmd/jiralert/content.go
+++ b/cmd/jiralert/content.go
@@ -101,7 +101,7 @@ func HomeHandlerFunc() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
 			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte("only GET allowed")) //nolint:errcheck
+			_, _ = w.Write([]byte("only GET allowed"))
 			return
 		}
 
@@ -118,7 +118,7 @@ func ConfigHandlerFunc(config *config.Config) func(http.ResponseWriter, *http.Re
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
 			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte("only GET allowed")) //nolint:errcheck
+			_, _ = w.Write([]byte("only GET allowed"))
 			return
 		}
 

--- a/cmd/jiralert/content.go
+++ b/cmd/jiralert/content.go
@@ -100,7 +100,7 @@ func pageTemplate(name string) *template.Template {
 func HomeHandlerFunc() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
-			w.WriteHeader(400)
+			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte("only GET allowed"))
 			return
 		}
@@ -117,7 +117,7 @@ func HomeHandlerFunc() func(http.ResponseWriter, *http.Request) {
 func ConfigHandlerFunc(config *config.Config) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
-			w.WriteHeader(400)
+			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte("only GET allowed"))
 			return
 		}

--- a/cmd/jiralert/content.go
+++ b/cmd/jiralert/content.go
@@ -99,6 +99,12 @@ func pageTemplate(name string) *template.Template {
 // HomeHandlerFunc is the HTTP handler for the home page (`/`).
 func HomeHandlerFunc() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			w.WriteHeader(400)
+			w.Write([]byte("only GET allowed"))
+			return
+		}
+
 		if err := homeTemplate.Execute(w, &tdata{
 			DocsURL: docsURL,
 		}); err != nil {
@@ -110,6 +116,12 @@ func HomeHandlerFunc() func(http.ResponseWriter, *http.Request) {
 // ConfigHandlerFunc is the HTTP handler for the `/config` page. It outputs the configuration marshaled in YAML format.
 func ConfigHandlerFunc(config *config.Config) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			w.WriteHeader(400)
+			w.Write([]byte("only GET allowed"))
+			return
+		}
+
 		if err := configTemplate.Execute(w, &tdata{
 			DocsURL: docsURL,
 			Config:  config.String(),

--- a/cmd/jiralert/content.go
+++ b/cmd/jiralert/content.go
@@ -101,7 +101,7 @@ func HomeHandlerFunc() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
 			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte("only GET allowed"))
+			w.Write([]byte("only GET allowed")) //nolint:errcheck
 			return
 		}
 
@@ -118,7 +118,7 @@ func ConfigHandlerFunc(config *config.Config) func(http.ResponseWriter, *http.Re
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
 			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte("only GET allowed"))
+			w.Write([]byte("only GET allowed")) //nolint:errcheck
 			return
 		}
 


### PR DESCRIPTION
I accidentally used `http://jiralert:9097/` as webhook url in alertmanager and searched for a full day, wondering why neither alertmanager nor jiralert logged an error :sweat_smile:

I propose this fix as a future safeguard for other poor souls like me:
Check request method on the home and config endpoints and error out if it's not a GET request