### PR TITLE
add editorconfig file to configure dev environment settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = false
+
+[*.{yaml,yml}]
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
Many projects (and even different file types like Makefile) have their own settings for things like space vs tabs and tab-sizes.

Editorconfig makes it easy to codify these settings in a project so that devs don't need to think (too much) about indent settings (and other stuff like line-endings)

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>