### PR TITLE
fix ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# JIRAlert 
-[![Build Status](https://travis-ci.org/prometheus-community/jiralert.svg)](https://travis-ci.org/prometheus-community/jiralert) 
+# JIRAlert
+[![Build Status](https://github.com/prometheus-community/jiralert/workflows/test/badge.svg?branch=master)](https://github.com/prometheus-community/jiralert/actions?query=workflow%3Atest) 
 [![Go Report Card](https://goreportcard.com/badge/github.com/prometheus-community/jiralert)](https://goreportcard.com/report/github.com/prometheus-community/jiralert) 
 [![GoDoc](https://godoc.org/github.com/prometheus-community/jiralert?status.svg)](https://godoc.org/github.com/prometheus-community/jiralert)
 [![Slack](https://img.shields.io/badge/join%20slack-%23jiralert-brightgreen.svg)](https://join.slack.com/t/improbable-eng/shared_invite/enQtMzQ1ODcyMzQ5MjM4LWY5ZWZmNGM2ODc5MmViNmQ3ZTA3ZTY3NzQwOTBlMTkzZmIxZTIxODk0OWU3YjZhNWVlNDU3MDlkZGViZjhkMjc)


### PR DESCRIPTION
This fixes the long-forgotten ci badge (was still pointing to travis ci) and points it towards our gh actions test pipeline

@bwplotka do you have rights to unpair jiralert from circleci and switch the required PR status check from circleci to gh actions?

Signed-off-by: Josh Gwosdz <jgwosdz@redhat.com>