### PR TITLE
Add support to auto resolve jira issue when alert is resolved.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-JIRAlert implements Alertmanager's webhook HTTP API and connects to one or more JIRA instances to create highly configurable JIRA issues. One issue is created per distinct group key — as defined by the [`group_by`](https://prometheus.io/docs/alerting/configuration/#<route>) parameter of Alertmanager's `route` configuration section. Issue opened will not be resolved automatically by default, however you can set `auto_resolve` field to override the default behavior.
+JIRAlert implements Alertmanager's webhook HTTP API and connects to one or more JIRA instances to create highly configurable JIRA issues. One issue is created per distinct group key — as defined by the [`group_by`](https://prometheus.io/docs/alerting/configuration/#<route>) parameter of Alertmanager's `route` configuration section. Issue opened will not be resolved automatically by default, however you can set `auto_resolve` section to override the default behavior.
 
 If a corresponding JIRA issue already exists but is resolved, it is reopened. A JIRA transition must exist between the resolved state and the reopened state — as defined by `reopen_state` — or reopening will fail. Optionally a "won't fix" resolution — defined by `wont_fix_resolution` — may be defined: a JIRA issue with this resolution will not be reopened by JIRAlert.
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,7 @@
 
 ## Overview
 
-JIRAlert implements Alertmanager's webhook HTTP API and connects to one or more JIRA instances to create highly configurable JIRA issues. One issue is created per distinct group key — as defined by the [`group_by`](https://prometheus.io/docs/alerting/configuration/#<route>) parameter of Alertmanager's `route` configuration section — but not closed when the alert is resolved. The expectation is that a human will look at the issue, take any necessary action, then close it.  If no human interaction is necessary then it should probably not alert in the first place. This behavior however can be modified
-by setting `auto_resolve` section, which will resolve the jira issue with required state.
-
-Issue opened will not be resolved automatically by default, however you can set `auto_resolve` section to override the default behavior.
+JIRAlert implements Alertmanager's webhook HTTP API and connects to one or more JIRA instances to create highly configurable JIRA issues. One issue is created per distinct group key — as defined by the [`group_by`](https://prometheus.io/docs/alerting/configuration/#<route>) parameter of Alertmanager's `route` configuration section — but not closed when the alert is resolved. The expectation is that a human will look at the issue, take any necessary action, then close it.  If no human interaction is necessary then it should probably not alert in the first place. This behavior however can be modified by setting `auto_resolve` section, which will resolve the jira issue with required state.
 
 If a corresponding JIRA issue already exists but is resolved, it is reopened. A JIRA transition must exist between the resolved state and the reopened state — as defined by `reopen_state` — or reopening will fail. Optionally a "won't fix" resolution — defined by `wont_fix_resolution` — may be defined: a JIRA issue with this resolution will not be reopened by JIRAlert.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-JIRAlert implements Alertmanager's webhook HTTP API and connects to one or more JIRA instances to create highly configurable JIRA issues. One issue is created per distinct group key — as defined by the [`group_by`](https://prometheus.io/docs/alerting/configuration/#<route>) parameter of Alertmanager's `route` configuration section — but not closed when the alert is resolved. The expectation is that a human will look at the issue, take any necessary action, then close it.  If no human interaction is necessary then it should probably not alert in the first place.
+JIRAlert implements Alertmanager's webhook HTTP API and connects to one or more JIRA instances to create highly configurable JIRA issues. One issue is created per distinct group key — as defined by the [`group_by`](https://prometheus.io/docs/alerting/configuration/#<route>) parameter of Alertmanager's `route` configuration section. Issue opened will not be resolved automatically by default, however you can set `auto_resolve` and `auto_resolve_state` to override default behavior.
 
 If a corresponding JIRA issue already exists but is resolved, it is reopened. A JIRA transition must exist between the resolved state and the reopened state — as defined by `reopen_state` — or reopening will fail. Optionally a "won't fix" resolution — defined by `wont_fix_resolution` — may be defined: a JIRA issue with this resolution will not be reopened by JIRAlert.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@
 
 ## Overview
 
-JIRAlert implements Alertmanager's webhook HTTP API and connects to one or more JIRA instances to create highly configurable JIRA issues. One issue is created per distinct group key — as defined by the [`group_by`](https://prometheus.io/docs/alerting/configuration/#<route>) parameter of Alertmanager's `route` configuration section. Issue opened will not be resolved automatically by default, however you can set `auto_resolve` section to override the default behavior.
+JIRAlert implements Alertmanager's webhook HTTP API and connects to one or more JIRA instances to create highly configurable JIRA issues. One issue is created per distinct group key — as defined by the [`group_by`](https://prometheus.io/docs/alerting/configuration/#<route>) parameter of Alertmanager's `route` configuration section — but not closed when the alert is resolved. The expectation is that a human will look at the issue, take any necessary action, then close it.  If no human interaction is necessary then it should probably not alert in the first place. This behavior however can be modified
+by setting `auto_resolve` section, which will resolve the jira issue with required state.
+
+Issue opened will not be resolved automatically by default, however you can set `auto_resolve` section to override the default behavior.
 
 If a corresponding JIRA issue already exists but is resolved, it is reopened. A JIRA transition must exist between the resolved state and the reopened state — as defined by `reopen_state` — or reopening will fail. Optionally a "won't fix" resolution — defined by `wont_fix_resolution` — may be defined: a JIRA issue with this resolution will not be reopened by JIRAlert.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-JIRAlert implements Alertmanager's webhook HTTP API and connects to one or more JIRA instances to create highly configurable JIRA issues. One issue is created per distinct group key — as defined by the [`group_by`](https://prometheus.io/docs/alerting/configuration/#<route>) parameter of Alertmanager's `route` configuration section. Issue opened will not be resolved automatically by default, however you can set `auto_resolve` and `auto_resolve_state` to override default behavior.
+JIRAlert implements Alertmanager's webhook HTTP API and connects to one or more JIRA instances to create highly configurable JIRA issues. One issue is created per distinct group key — as defined by the [`group_by`](https://prometheus.io/docs/alerting/configuration/#<route>) parameter of Alertmanager's `route` configuration section. Issue opened will not be resolved automatically by default, however you can set `auto_resolve` field to override the default behavior.
 
 If a corresponding JIRA issue already exists but is resolved, it is reopened. A JIRA transition must exist between the resolved state and the reopened state — as defined by `reopen_state` — or reopening will fail. Optionally a "won't fix" resolution — defined by `wont_fix_resolution` — may be defined: a JIRA issue with this resolution will not be reopened by JIRAlert.
 

--- a/examples/jiralert.yml
+++ b/examples/jiralert.yml
@@ -30,7 +30,10 @@ receivers:
     project: AB
     # Copy all Prometheus labels into separate JIRA labels. Optional (default: false).
     add_group_labels: false
-
+    # Automatically resolve jira issues when alert is resolved. Optional (default: false)
+    auto_resolve: true
+    # Used for setting state when resolving the issue. Must be set if `auto_resolve` is set.
+    auto_resolve_state: "Done" 
   - name: 'jira-xy'
     project: XY
     # Overrides default.

--- a/examples/jiralert.yml
+++ b/examples/jiralert.yml
@@ -50,6 +50,10 @@ receivers:
       customfield_10002: {"value": "red"}
       # MultiSelect
       customfield_10003: [{"value": "red"}, {"value": "blue"}, {"value": "green"}]
+    #
+    # Automatically resolve jira issues when alert is resolved. Optional. If declared, ensure state is not an empty string.
+    auto_resolve:
+      state: 'Done' 
 
 # File containing template definitions. Required.
 template: jiralert.tmpl

--- a/examples/jiralert.yml
+++ b/examples/jiralert.yml
@@ -30,10 +30,6 @@ receivers:
     project: AB
     # Copy all Prometheus labels into separate JIRA labels. Optional (default: false).
     add_group_labels: false
-    # Automatically resolve jira issues when alert is resolved. Optional (default: false)
-    auto_resolve: true
-    # Used for setting state when resolving the issue. Must be set if `auto_resolve` is set.
-    auto_resolve_state: "Done" 
   - name: 'jira-xy'
     project: XY
     # Overrides default.

--- a/examples/jiralert.yml
+++ b/examples/jiralert.yml
@@ -30,6 +30,7 @@ receivers:
     project: AB
     # Copy all Prometheus labels into separate JIRA labels. Optional (default: false).
     add_group_labels: false
+
   - name: 'jira-xy'
     project: XY
     # Overrides default.

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -27,6 +27,9 @@ const (
 
 	// AlertFiring is the status value for a firing alert.
 	AlertFiring = "firing"
+
+	// AlertResolved is the status value for a resolved alert.
+	AlertResolved = "resolved"
 )
 
 // Pair is a key/value string pair.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -88,6 +88,10 @@ func resolveFilepaths(baseDir string, cfg *Config, logger log.Logger) {
 	cfg.Template = join(cfg.Template)
 }
 
+type AutoResolve struct {
+	State string `yaml:"state" json:"state"`
+}
+
 // ReceiverConfig is the configuration for one receiver. It has a unique name and includes API access fields (url and
 // auth) and issue fields (required -- e.g. project, issue type -- and optional -- e.g. priority).
 type ReceiverConfig struct {
@@ -117,8 +121,7 @@ type ReceiverConfig struct {
 	AddGroupLabels bool `yaml:"add_group_labels" json:"add_group_labels"`
 
 	// Flag to auto resolve opened issue when alert is resolved
-	AutoResolve      bool   `yaml:"auto_resolve" json:"auto_resolve"`
-	AutoResolveState string `yaml:"auto_resolve_state" json:"auto_resolve_state"`
+	AutoResolve *AutoResolve `yaml:"auto_resolve" json:"auto_resolve"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`
@@ -173,6 +176,12 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	if (c.Defaults.User != "" || c.Defaults.Password != "") && c.Defaults.PersonalAccessToken != "" {
 		return fmt.Errorf("bad auth config in defaults section: user/password and PAT authentication are mutually exclusive")
+	}
+
+	if c.Defaults.AutoResolve != nil {
+		if c.Defaults.AutoResolve.State == "" {
+			return fmt.Errorf("bad config in defaults section: state cannot be empty")
+		}
 	}
 
 	for _, rc := range c.Receivers {
@@ -255,11 +264,13 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if rc.WontFixResolution == "" && c.Defaults.WontFixResolution != "" {
 			rc.WontFixResolution = c.Defaults.WontFixResolution
 		}
-		if rc.AutoResolveState == "" && c.Defaults.AutoResolveState != "" {
-			rc.AutoResolveState = c.Defaults.AutoResolveState
+		if rc.AutoResolve != nil {
+			if rc.AutoResolve.State == "" {
+				return fmt.Errorf("bad config in receiver %q, state cannot be empty", rc.Name)
+			}
 		}
-		if rc.AutoResolve == true && rc.AutoResolveState == "" {
-			return fmt.Errorf("bad config in receiver section: auto_resolve_state must be defined when auto_resolve is set to true")
+		if rc.AutoResolve == nil && c.Defaults.AutoResolve != nil {
+			rc.AutoResolve = c.Defaults.AutoResolve
 		}
 		if len(c.Defaults.Fields) > 0 {
 			for key, value := range c.Defaults.Fields {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -117,7 +117,8 @@ type ReceiverConfig struct {
 	AddGroupLabels bool `yaml:"add_group_labels" json:"add_group_labels"`
 
 	// Flag to auto resolve opened issue when alert is resolved
-	AutoResolve bool `yaml:"auto_resolve" json:"auto_resolve"`
+	AutoResolve      bool   `yaml:"auto_resolve" json:"auto_resolve"`
+	AutoResolveState string `yaml:"auto_resolve_state" json:"auto_resolve_state"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -116,6 +116,9 @@ type ReceiverConfig struct {
 	// Label copy settings
 	AddGroupLabels bool `yaml:"add_group_labels" json:"add_group_labels"`
 
+	// Flag to auto resolve opened issue when alert is resolved
+	AutoResolve bool `yaml:"auto_resolve" json:"auto_resolve"`
+
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -175,6 +175,10 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return fmt.Errorf("bad auth config in defaults section: user/password and PAT authentication are mutually exclusive")
 	}
 
+	if c.Defaults.AutoResolve == true && c.Defaults.AutoResolveState == "" {
+		return fmt.Errorf("bad config in defaults section: auto_resolve_state must be defined when auto_resolve is set to true")
+	}
+
 	for _, rc := range c.Receivers {
 		if rc.Name == "" {
 			return fmt.Errorf("missing name for receiver %+v", rc)
@@ -254,6 +258,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 		if rc.WontFixResolution == "" && c.Defaults.WontFixResolution != "" {
 			rc.WontFixResolution = c.Defaults.WontFixResolution
+		}
+		if rc.AutoResolveState == "" && c.Defaults.AutoResolveState != "" {
+			rc.AutoResolveState = c.Defaults.AutoResolveState
 		}
 		if len(c.Defaults.Fields) > 0 {
 			for key, value := range c.Defaults.Fields {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -121,7 +121,7 @@ type ReceiverConfig struct {
 	// Label copy settings
 	AddGroupLabels bool `yaml:"add_group_labels" json:"add_group_labels"`
 
-	// Flag to auto resolve opened issue when alert is resolved
+	// Flag to auto-resolve opened issue when the alert is resolved.
 	AutoResolve *AutoResolve `yaml:"auto_resolve" json:"auto_resolve"`
 
 	// Catches all undefined fields and must be empty after parsing.
@@ -267,7 +267,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 		if rc.AutoResolve != nil {
 			if rc.AutoResolve.State == "" {
-				return fmt.Errorf("bad config in receiver %q, state cannot be empty", rc.Name)
+				return fmt.Errorf("bad config in receiver %q, 'auto_resolve' was defined with empty 'state' field", rc.Name)
 			}
 		}
 		if rc.AutoResolve == nil && c.Defaults.AutoResolve != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -175,10 +175,6 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return fmt.Errorf("bad auth config in defaults section: user/password and PAT authentication are mutually exclusive")
 	}
 
-	if c.Defaults.AutoResolve == true && c.Defaults.AutoResolveState == "" {
-		return fmt.Errorf("bad config in defaults section: auto_resolve_state must be defined when auto_resolve is set to true")
-	}
-
 	for _, rc := range c.Receivers {
 		if rc.Name == "" {
 			return fmt.Errorf("missing name for receiver %+v", rc)
@@ -261,6 +257,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 		if rc.AutoResolveState == "" && c.Defaults.AutoResolveState != "" {
 			rc.AutoResolveState = c.Defaults.AutoResolveState
+		}
+		if rc.AutoResolve == true && rc.AutoResolveState == "" {
+			return fmt.Errorf("bad config in receiver section: auto_resolve_state must be defined when auto_resolve is set to true")
 		}
 		if len(c.Defaults.Fields) > 0 {
 			for key, value := range c.Defaults.Fields {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -88,6 +88,7 @@ func resolveFilepaths(baseDir string, cfg *Config, logger log.Logger) {
 	cfg.Template = join(cfg.Template)
 }
 
+// AutoResolve is the struct used for defining jira resolution state when alert is resolved.
 type AutoResolve struct {
 	State string `yaml:"state" json:"state"`
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -111,16 +111,11 @@ type receiverTestConfig struct {
 	WontFixResolution string `yaml:"wont_fix_resolution,omitempty"`
 	AddGroupLabels    bool   `yaml:"add_group_labels,omitempty"`
 
-	AutoResolve *testAutoResolve `yaml:"auto_resolve" json:"auto_resolve"`
+	AutoResolve *AutoResolve `yaml:"auto_resolve" json:"auto_resolve"`
 
 	// TODO(rporres): Add support for these.
 	// Fields            map[string]interface{} `yaml:"fields,omitempty"`
 	// Components        []string               `yaml:"components,omitempty"`
-}
-
-// A test version of the AutoResolve struct to create test yaml fixtures.
-type testAutoResolve struct {
-	State string `yaml:"state" json:"state"`
 }
 
 // A test version of the Config struct to create test yaml fixtures.
@@ -316,7 +311,7 @@ func TestReceiverOverrides(t *testing.T) {
 		{"Description", "A nice description", "A nice description"},
 		{"WontFixResolution", "Won't Fix", "Won't Fix"},
 		{"AddGroupLabels", false, false},
-		{"AutoResolve", &testAutoResolve{State: "Done"}, &auto_resolve},
+		{"AutoResolve", &AutoResolve{State: "Done"}, &auto_resolve},
 	} {
 		optionalFields := []string{"Priority", "Description", "WontFixResolution", "AddGroupLabels", "AutoResolve"}
 		defaultsConfig := newReceiverTestConfig(mandatoryReceiverFields(), optionalFields)
@@ -371,7 +366,7 @@ func newReceiverTestConfig(mandatory []string, optional []string) *receiverTestC
 		if name == "AddGroupLabels" {
 			value = reflect.ValueOf(true)
 		} else if name == "AutoResolve" {
-			value = reflect.ValueOf(&testAutoResolve{State: "Done"})
+			value = reflect.ValueOf(&AutoResolve{State: "Done"})
 		} else {
 			value = reflect.ValueOf(name)
 		}
@@ -415,7 +410,7 @@ func TestAutoResolveConfigReceiver(t *testing.T) {
 	mandatory := mandatoryReceiverFields()
 	minimalReceiverTestConfig := &receiverTestConfig{
 		Name: "test",
-		AutoResolve: &testAutoResolve{
+		AutoResolve: &AutoResolve{
 			State: "",
 		},
 	}
@@ -436,7 +431,7 @@ func TestAutoResolveConfigDefault(t *testing.T) {
 	minimalReceiverTestConfig := newReceiverTestConfig([]string{"Name"}, []string{"AutoResolve"})
 
 	defaultsConfig := newReceiverTestConfig(mandatory, []string{})
-	defaultsConfig.AutoResolve = &testAutoResolve{
+	defaultsConfig.AutoResolve = &AutoResolve{
 		State: "",
 	}
 	config := testConfig{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -292,7 +292,7 @@ func TestAuthKeysOverrides(t *testing.T) {
 // No tests for auth keys here. They will be handled separately
 func TestReceiverOverrides(t *testing.T) {
 	fifteenHoursToDuration, err := ParseDuration("15h")
-	auto_resolve := AutoResolve{State: "Done"}
+	autoResolve := AutoResolve{State: "Done"}
 	require.NoError(t, err)
 
 	// We'll override one key at a time and check the value in the receiver.
@@ -311,7 +311,7 @@ func TestReceiverOverrides(t *testing.T) {
 		{"Description", "A nice description", "A nice description"},
 		{"WontFixResolution", "Won't Fix", "Won't Fix"},
 		{"AddGroupLabels", false, false},
-		{"AutoResolve", &AutoResolve{State: "Done"}, &auto_resolve},
+		{"AutoResolve", &AutoResolve{State: "Done"}, &autoResolve},
 	} {
 		optionalFields := []string{"Priority", "Description", "WontFixResolution", "AddGroupLabels", "AutoResolve"}
 		defaultsConfig := newReceiverTestConfig(mandatoryReceiverFields(), optionalFields)
@@ -422,7 +422,7 @@ func TestAutoResolveConfigReceiver(t *testing.T) {
 		Template:  "jiralert.tmpl",
 	}
 
-	configErrorTestRunner(t, config, "bad config in receiver \"test\", state cannot be empty")
+	configErrorTestRunner(t, config, "bad config in receiver \"test\", 'auto_resolve' was defined with empty 'state' field")
 
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -409,18 +409,15 @@ func mandatoryReceiverFields() []string {
 
 func TestAutoResolveConfig(t *testing.T) {
 	mandatory := mandatoryReceiverFields()
-	minimalReceiverTestConfig := newReceiverTestConfig([]string{"Name"}, []string{})
+	minimalReceiverTestConfig := newReceiverTestConfig([]string{"Name"}, []string{"AutoResolve"})
 
-	// Test cases:
-	// * missing auto_resolve_state
-
-	defaultsConfig := newReceiverTestConfig(mandatory, []string{"AutoResolve"})
+	defaultsConfig := newReceiverTestConfig(mandatory, []string{})
 	config := testConfig{
 		Defaults:  defaultsConfig,
 		Receivers: []*receiverTestConfig{minimalReceiverTestConfig},
 		Template:  "jiralert.tmpl",
 	}
 
-	configErrorTestRunner(t, config, "bad config in defaults section: auto_resolve_state must be defined when auto_resolve is set to true")
+	configErrorTestRunner(t, config, "bad config in receiver section: auto_resolve_state must be defined when auto_resolve is set to true")
 
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -118,6 +118,7 @@ type receiverTestConfig struct {
 	// Components        []string               `yaml:"components,omitempty"`
 }
 
+// A test version of the AutoResolve struct to create test yaml fixtures.
 type testAutoResolve struct {
 	State string `yaml:"state" json:"state"`
 }

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -108,11 +108,10 @@ func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool) (bool, er
 					return retry, err
 				}
 				return false, nil
-
-			} else {
-				level.Debug(r.logger).Log("msg", "no firing alert; summary checked, nothing else to do.", "key", issue.Key, "label", issueGroupLabel)
-				return false, nil
 			}
+
+			level.Debug(r.logger).Log("msg", "no firing alert; summary checked, nothing else to do.", "key", issue.Key, "label", issueGroupLabel)
+			return false, nil
 		}
 
 		// The set of JIRA status categories is fixed, this is a safe check to make.

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -101,7 +101,7 @@ func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool) (bool, er
 		}
 
 		if len(data.Alerts.Firing()) == 0 {
-			if r.conf.AutoResolve {
+			if r.conf.AutoResolve != nil {
 				level.Debug(r.logger).Log("msg", "no firing alert; resolving issue", "key", issue.Key, "label", issueGroupLabel)
 				retry, err := r.resolveIssue(issue.Key)
 				if err != nil {
@@ -385,7 +385,7 @@ func handleJiraErrResponse(api string, resp *jira.Response, err error, logger lo
 }
 
 func (r *Receiver) resolveIssue(issueKey string) (bool, error) {
-	return r.doTransition(issueKey, r.conf.AutoResolveState)
+	return r.doTransition(issueKey, r.conf.AutoResolve.State)
 }
 
 func (r *Receiver) doTransition(issueKey string, transitionState string) (bool, error) {

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -176,14 +176,14 @@ func testReceiverConfig2() *config.ReceiverConfig {
 
 func testReceiverConfigAutoResolve() *config.ReceiverConfig {
 	reopen := config.Duration(1 * time.Hour)
+	auto_resolve := config.AutoResolve{State: "Done"}
 	return &config.ReceiverConfig{
 		Project:           "abc",
 		Summary:           `[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }} {{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}`,
 		ReopenDuration:    &reopen,
 		ReopenState:       "reopened",
 		WontFixResolution: "won't-fix",
-		AutoResolve:       true,
-		AutoResolveState:  "Done",
+		AutoResolve:       &auto_resolve,
 	}
 }
 

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -134,7 +134,7 @@ func (f *fakeJira) UpdateWithOptions(old *jira.Issue, _ *jira.UpdateQueryOptions
 
 		if old.Fields.Resolution.Name == "done" {
 			issue.Fields.Status = &jira.Status{
-				StatusCategory: jira.StatusCategory{Key: "done"},
+				StatusCategory: jira.StatusCategory{Key: jira.StatusCategoryComplete},
 			}
 		}
 	}
@@ -535,7 +535,7 @@ func TestNotify_JIRAInteraction(t *testing.T) {
 						Project: jira.Project{Key: testReceiverConfig2().Project},
 						Labels:  []string{"JIRALERT{819ba5ecba4ea5946a8d17d285cb23f3bb6862e08bb602ab08fd231cd8e1a83a1d095b0208a661787e9035f0541817634df5a994d1b5d4200d6c68a7663c97f5}"},
 						Status: &jira.Status{
-							StatusCategory: jira.StatusCategory{Key: "done"},
+							StatusCategory: jira.StatusCategory{Key: jira.StatusCategoryComplete},
 						},
 						Resolution: &jira.Resolution{
 							Name: "done",

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -46,7 +46,7 @@ type fakeJira struct {
 func newTestFakeJira() *fakeJira {
 	return &fakeJira{
 		issuesByKey:     map[string]*jira.Issue{},
-		transitionsByID: map[string]jira.Transition{},
+		transitionsByID: map[string]jira.Transition{"1234": {ID: "1234", Name: "Done"}},
 		keysByQuery:     map[string][]string{},
 	}
 }
@@ -129,16 +129,6 @@ func (f *fakeJira) UpdateWithOptions(old *jira.Issue, _ *jira.UpdateQueryOptions
 		issue.Fields.Description = old.Fields.Description
 	}
 
-	if old.Fields.Resolution != nil {
-		issue.Fields.Resolution = old.Fields.Resolution
-
-		if old.Fields.Resolution.Name == "done" {
-			issue.Fields.Status = &jira.Status{
-				StatusCategory: jira.StatusCategory{Key: jira.StatusCategoryComplete},
-			}
-		}
-	}
-
 	f.issuesByKey[issue.Key] = issue
 	return issue, nil, nil
 }
@@ -193,6 +183,7 @@ func testReceiverConfig3() *config.ReceiverConfig {
 		ReopenState:       "reopened",
 		WontFixResolution: "won't-fix",
 		AutoResolve:       true,
+		AutoResolveState:  "Done",
 	}
 }
 
@@ -532,13 +523,10 @@ func TestNotify_JIRAInteraction(t *testing.T) {
 					ID:  "1",
 					Key: "1",
 					Fields: &jira.IssueFields{
-						Project: jira.Project{Key: testReceiverConfig2().Project},
+						Project: jira.Project{Key: testReceiverConfig3().Project},
 						Labels:  []string{"JIRALERT{819ba5ecba4ea5946a8d17d285cb23f3bb6862e08bb602ab08fd231cd8e1a83a1d095b0208a661787e9035f0541817634df5a994d1b5d4200d6c68a7663c97f5}"},
 						Status: &jira.Status{
-							StatusCategory: jira.StatusCategory{Key: jira.StatusCategoryComplete},
-						},
-						Resolution: &jira.Resolution{
-							Name: "done",
+							StatusCategory: jira.StatusCategory{Key: "Done"},
 						},
 						Unknowns:    tcontainer.MarshalMap{},
 						Summary:     "[RESOLVED] b d ", // Title changed.

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -129,6 +129,16 @@ func (f *fakeJira) UpdateWithOptions(old *jira.Issue, _ *jira.UpdateQueryOptions
 		issue.Fields.Description = old.Fields.Description
 	}
 
+	if old.Fields.Resolution != nil {
+		issue.Fields.Resolution = old.Fields.Resolution
+
+		if old.Fields.Resolution.Name == "done" {
+			issue.Fields.Status = &jira.Status{
+				StatusCategory: jira.StatusCategory{Key: "done"},
+			}
+		}
+	}
+
 	f.issuesByKey[issue.Key] = issue
 	return issue, nil, nil
 }
@@ -171,6 +181,18 @@ func testReceiverConfig2() *config.ReceiverConfig {
 		ReopenState:       "reopened",
 		Description:       `{{ .Alerts.Firing | len }}`,
 		WontFixResolution: "won't-fix",
+	}
+}
+
+func testReceiverConfig3() *config.ReceiverConfig {
+	reopen := config.Duration(1 * time.Hour)
+	return &config.ReceiverConfig{
+		Project:           "abc",
+		Summary:           `[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }} {{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}`,
+		ReopenDuration:    &reopen,
+		ReopenState:       "reopened",
+		WontFixResolution: "won't-fix",
+		AutoResolve:       true,
 	}
 }
 
@@ -475,6 +497,52 @@ func TestNotify_JIRAInteraction(t *testing.T) {
 						},
 						Unknowns: tcontainer.MarshalMap{},
 						Summary:  "[FIRING:1] b d ", // Title changed.
+					},
+				},
+			},
+		},
+		{
+			name:        "auto resolve alert",
+			inputConfig: testReceiverConfig3(),
+			inputAlert: &alertmanager.Data{
+				Alerts: alertmanager.Alerts{
+					{Status: "resolved"},
+				},
+				Status:      alertmanager.AlertResolved,
+				GroupLabels: alertmanager.KV{"a": "b", "c": "d"},
+			},
+			initJira: func(t *testing.T) *fakeJira {
+				f := newTestFakeJira()
+				_, _, err := f.Create(&jira.Issue{
+					ID:  "1",
+					Key: "1",
+					Fields: &jira.IssueFields{
+						Project:     jira.Project{Key: testReceiverConfig3().Project},
+						Labels:      []string{"JIRALERT{819ba5ecba4ea5946a8d17d285cb23f3bb6862e08bb602ab08fd231cd8e1a83a1d095b0208a661787e9035f0541817634df5a994d1b5d4200d6c68a7663c97f5}"},
+						Unknowns:    tcontainer.MarshalMap{},
+						Summary:     "[FIRING:2] b d ",
+						Description: "1",
+					},
+				})
+				require.NoError(t, err)
+				return f
+			},
+			expectedJiraIssues: map[string]*jira.Issue{
+				"1": {
+					ID:  "1",
+					Key: "1",
+					Fields: &jira.IssueFields{
+						Project: jira.Project{Key: testReceiverConfig2().Project},
+						Labels:  []string{"JIRALERT{819ba5ecba4ea5946a8d17d285cb23f3bb6862e08bb602ab08fd231cd8e1a83a1d095b0208a661787e9035f0541817634df5a994d1b5d4200d6c68a7663c97f5}"},
+						Status: &jira.Status{
+							StatusCategory: jira.StatusCategory{Key: "done"},
+						},
+						Resolution: &jira.Resolution{
+							Name: "done",
+						},
+						Unknowns:    tcontainer.MarshalMap{},
+						Summary:     "[RESOLVED] b d ", // Title changed.
+						Description: "1",
 					},
 				},
 			},

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -174,7 +174,7 @@ func testReceiverConfig2() *config.ReceiverConfig {
 	}
 }
 
-func testReceiverConfig3() *config.ReceiverConfig {
+func testReceiverConfigAutoResolve() *config.ReceiverConfig {
 	reopen := config.Duration(1 * time.Hour)
 	return &config.ReceiverConfig{
 		Project:           "abc",
@@ -494,7 +494,7 @@ func TestNotify_JIRAInteraction(t *testing.T) {
 		},
 		{
 			name:        "auto resolve alert",
-			inputConfig: testReceiverConfig3(),
+			inputConfig: testReceiverConfigAutoResolve(),
 			inputAlert: &alertmanager.Data{
 				Alerts: alertmanager.Alerts{
 					{Status: "resolved"},
@@ -508,7 +508,7 @@ func TestNotify_JIRAInteraction(t *testing.T) {
 					ID:  "1",
 					Key: "1",
 					Fields: &jira.IssueFields{
-						Project:     jira.Project{Key: testReceiverConfig3().Project},
+						Project:     jira.Project{Key: testReceiverConfigAutoResolve().Project},
 						Labels:      []string{"JIRALERT{819ba5ecba4ea5946a8d17d285cb23f3bb6862e08bb602ab08fd231cd8e1a83a1d095b0208a661787e9035f0541817634df5a994d1b5d4200d6c68a7663c97f5}"},
 						Unknowns:    tcontainer.MarshalMap{},
 						Summary:     "[FIRING:2] b d ",
@@ -523,7 +523,7 @@ func TestNotify_JIRAInteraction(t *testing.T) {
 					ID:  "1",
 					Key: "1",
 					Fields: &jira.IssueFields{
-						Project: jira.Project{Key: testReceiverConfig3().Project},
+						Project: jira.Project{Key: testReceiverConfigAutoResolve().Project},
 						Labels:  []string{"JIRALERT{819ba5ecba4ea5946a8d17d285cb23f3bb6862e08bb602ab08fd231cd8e1a83a1d095b0208a661787e9035f0541817634df5a994d1b5d4200d6c68a7663c97f5}"},
 						Status: &jira.Status{
 							StatusCategory: jira.StatusCategory{Key: "Done"},

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -176,14 +176,14 @@ func testReceiverConfig2() *config.ReceiverConfig {
 
 func testReceiverConfigAutoResolve() *config.ReceiverConfig {
 	reopen := config.Duration(1 * time.Hour)
-	auto_resolve := config.AutoResolve{State: "Done"}
+	autoResolve := config.AutoResolve{State: "Done"}
 	return &config.ReceiverConfig{
 		Project:           "abc",
 		Summary:           `[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }} {{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}`,
 		ReopenDuration:    &reopen,
 		ReopenState:       "reopened",
 		WontFixResolution: "won't-fix",
-		AutoResolve:       &auto_resolve,
+		AutoResolve:       &autoResolve,
 	}
 }
 


### PR DESCRIPTION
This is a feature enhancement from Red Hat. 

The background is we use jiralert extensively in our observability stack and have found certain use-cases where we want to auto resolve issues created. We acknowledge current decisions regarding not resolving the issues by default hence we are introducing this optional feature to override the default behavior.

Following changes were required to enable this feature
- Add `AutoResolve` struct to `ReceiverConfig`  set the status of jira issue when alert is resolved. 
- Update `Notify` method to utilize newly added flag to resolve jira issues when `auto_resolve` configuration section is set, otherwise default to no action.
- Small refactor to utilize jira transition logic for reopening and resolving issue. 

I have added unit tests for newly added code as well as tested it against live jira instance. 

Also please feel free to suggest any feedback around Go as I haven't had much experience with it around best practices. 

Thanks!