### PR TITLE
Better Jira error handling

### DIFF
--- a/cmd/jiralert/main.go
+++ b/cmd/jiralert/main.go
@@ -17,12 +17,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/andygrunwald/go-jira"
 	"net/http"
 	"os"
 	"runtime"
 	"strconv"
 
+	"github.com/andygrunwald/go-jira"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus-community/jiralert/pkg/alertmanager"
@@ -127,7 +127,8 @@ func main() {
 				// Instruct Alertmanager to retry.
 				status = http.StatusServiceUnavailable
 			} else {
-				status = http.StatusInternalServerError
+				// Inaccurate, just letting Alertmanager know that it should not retry.
+				status = http.StatusBadRequest
 			}
 			errorHandler(w, status, err, conf.Name, &data, logger)
 			return

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -17,12 +17,11 @@ import (
 	"bytes"
 	"crypto/sha512"
 	"fmt"
-	"github.com/andygrunwald/go-jira"
-	"io"
 	"reflect"
 	"strings"
 	"time"
 
+	"github.com/andygrunwald/go-jira"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
@@ -377,9 +376,7 @@ func handleJiraErrResponse(api string, resp *jira.Response, err error, logger lo
 
 	if resp != nil && resp.StatusCode/100 != 2 {
 		retry := resp.StatusCode == 500 || resp.StatusCode == 503
-		body, _ := io.ReadAll(resp.Body)
-		// go-jira error message is not particularly helpful, replace it
-		return retry, errors.Errorf("JIRA request %s returned status %s, body %q", resp.Request.URL, resp.Status, string(body))
+		return retry, errors.Errorf("JIRA request %s returned status %s, error %q", resp.Request.URL, resp.Status, err)
 	}
 	return false, errors.Wrapf(err, "JIRA request %s failed", api)
 }

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -375,7 +375,7 @@ func handleJiraErrResponse(api string, resp *jira.Response, err error, logger lo
 	}
 
 	if resp != nil && resp.StatusCode/100 != 2 {
-		retry := resp.StatusCode == 500 || resp.StatusCode == 503
+		retry := resp.StatusCode == 500 || resp.StatusCode == 503 || resp.StatusCode == 429
 		return retry, errors.Errorf("JIRA request %s returned status %s, error %q", resp.Request.URL, resp.Status, err)
 	}
 	return false, errors.Wrapf(err, "JIRA request %s failed", api)


### PR DESCRIPTION
* Return HTTP 400 Bad Request for non-retriable errors. It is inaccurate, but will prevent alertmanager from retrying.
* Turns out go-jira does actually produce useful error messages (and it consumes the response body in the process). Log that instead of the empty body.
* Also include HTTP response status 429 among retriable errors.

This addresses a number of currently open issues, including #132, #97 and #53.

Signed-off-by: Alin Sinpalean <alin.sinpalean@gmail.com>