### PR TITLE
feat: add common labels to issue

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,30 @@
+name: Docker Image CI
+
+on: 
+  workflow_dispatch:
+    inputs: 
+      version:
+        required: true
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Docker Login
+      # You may pin to the exact commit or the version.
+      # uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
+      uses: docker/login-action@v2.0.0
+      with:
+        username: ${{secrets.DOCKERHUB_USERNAME}}
+        password: ${{secrets.DOCKERHUB_PASSWORD}}
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag crikke95/jiralert:${{github.event.inputs.version}}
+    - name: Docker push
+      run: docker push crikke95/jiralert:${{github.event.inputs.version}}
+    

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -146,7 +146,8 @@ type ReceiverConfig struct {
 	Components        []string               `yaml:"components" json:"components"`
 
 	// Label copy settings
-	AddGroupLabels bool `yaml:"add_group_labels" json:"add_group_labels"`
+	AddGroupLabels  bool `yaml:"add_group_labels" json:"add_group_labels"`
+	AddCommonLabels bool `yaml:"add_common_labels" json:"add_common_labels"`
 
 	// Flag to auto-resolve opened issue when the alert is resolved.
 	AutoResolve *AutoResolve `yaml:"auto_resolve" json:"auto_resolve"`

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -89,11 +89,9 @@ func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool) (bool, er
 		for _, pair := range data.CommonLabels.SortedPairs() {
 			labels = append(labels, fmt.Sprintf("%s=%q", pair.Name, pair.Value))
 		}
-		labels = append(labels, toChecksumTicketLabel(labels))
-	} else {
-		labels = append(labels, toGroupTicketLabel(data.GroupLabels, hashJiraLabel))
 	}
 
+	labels = append(labels, toGroupTicketLabel(data.GroupLabels, hashJiraLabel))
 	issue, retry, err := r.findIssueToReuse(project, labels[len(labels)-1])
 	if err != nil {
 		return retry, err

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -173,6 +173,18 @@ func testReceiverConfig2() *config.ReceiverConfig {
 		WontFixResolution: "won't-fix",
 	}
 }
+func testReceiverConfig3() *config.ReceiverConfig {
+	reopen := config.Duration(1 * time.Hour)
+	return &config.ReceiverConfig{
+		Project:           "abc",
+		Summary:           `[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }} {{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}`,
+		ReopenDuration:    &reopen,
+		ReopenState:       "reopened",
+		Description:       `{{ .Alerts.Firing | len }}`,
+		WontFixResolution: "won't-fix",
+		AddCommonLabels:   true,
+	}
+}
 
 func testReceiverConfigAutoResolve() *config.ReceiverConfig {
 	reopen := config.Duration(1 * time.Hour)
@@ -197,6 +209,40 @@ func TestNotify_JIRAInteraction(t *testing.T) {
 		initJira           func(t *testing.T) *fakeJira
 		expectedJiraIssues map[string]*jira.Issue
 	}{
+		{
+			name:        "empty jira, add common labels",
+			inputConfig: testReceiverConfig3(),
+			initJira:    func(t *testing.T) *fakeJira { return newTestFakeJira() },
+			inputAlert: &alertmanager.Data{
+				CommonLabels: alertmanager.KV{"foo": "bar"},
+				Alerts: alertmanager.Alerts{
+					{Status: alertmanager.AlertFiring},
+					{Status: "not firing"},
+					{Status: alertmanager.AlertFiring},
+				},
+				Status:      alertmanager.AlertFiring,
+				GroupLabels: alertmanager.KV{"a": "b", "c": "d"},
+			},
+			expectedJiraIssues: map[string]*jira.Issue{
+				"1": {
+					ID:  "1",
+					Key: "1",
+					Fields: &jira.IssueFields{
+						Project: jira.Project{Key: testReceiverConfig1().Project},
+						Labels: []string{
+							`foo="bar"`,
+							"Jiralert-checksum=ab03a89430228717b59a73fe39f7b6a44aa79408",
+						},
+						Description: "2",
+						Status: &jira.Status{
+							StatusCategory: jira.StatusCategory{Key: "NotDone"},
+						},
+						Unknowns: tcontainer.MarshalMap{},
+						Summary:  "[FIRING:2] b d ",
+					},
+				},
+			},
+		},
 		{
 			name:        "empty jira, new alert group",
 			inputConfig: testReceiverConfig1(),


### PR DESCRIPTION
We have multiple environments in which each alert has a env label. To improve filtering in Jira common labels for all alerts in a given group can be added to the labels field. 

