### PR TITLE
Adding getEnv templating function

### DIFF
--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -15,6 +15,7 @@ package template
 
 import (
 	"bytes"
+	"os"
 	"regexp"
 	"strings"
 	"text/template"
@@ -46,6 +47,9 @@ var funcs = template.FuncMap{
 	},
 	"stringSlice": func(s ...string) []string {
 		return s
+	},
+	"getEnv": func(name string) string {
+		return os.Getenv(name)
 	},
 }
 


### PR DESCRIPTION
This PR is adding a new templating function that can be used to insert values of environment variables into the template file. There already is similar functionality for the configuration file (using the `$(var)` syntax) so it would be great to have the same possibility in the template file.