### PR TITLE
Allowing selected (custom/standard) fields to be updated

### DIFF
--- a/examples/jiralert.yml
+++ b/examples/jiralert.yml
@@ -64,6 +64,11 @@ receivers:
       # MultiSelect
       customfield_10003: [{"value": "red"}, {"value": "blue"}, {"value": "green"}]
     #
+    # List of standard or custom field names which values will be updated. Optional.
+    update_always_fields:
+      - customfield_10001
+      - customfield_10003
+    #
     # Automatically resolve jira issues when alert is resolved. Optional. If declared, ensure state is not an empty string.
     auto_resolve:
       state: 'Done'

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -146,7 +146,7 @@ type ReceiverConfig struct {
 	Fields               map[string]interface{} `yaml:"fields" json:"fields"`
 	Components           []string               `yaml:"components" json:"components"`
 	StaticLabels         []string               `yaml:"static_labels" json:"static_labels"`
-	CustomFieldsToUpdate []string               `yaml:"update_always_fields" json:"update_always_fields"`
+	FieldsToUpdate []string               `yaml:"update_always_fields" json:"update_always_fields"`
 
 	// Label copy settings
 	AddGroupLabels *bool `yaml:"add_group_labels" json:"add_group_labels"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -140,13 +140,13 @@ type ReceiverConfig struct {
 	ReopenDuration *Duration `yaml:"reopen_duration" json:"reopen_duration"`
 
 	// Optional issue fields
-	Priority             string                 `yaml:"priority" json:"priority"`
-	Description          string                 `yaml:"description" json:"description"`
-	WontFixResolution    string                 `yaml:"wont_fix_resolution" json:"wont_fix_resolution"`
-	Fields               map[string]interface{} `yaml:"fields" json:"fields"`
-	Components           []string               `yaml:"components" json:"components"`
-	StaticLabels         []string               `yaml:"static_labels" json:"static_labels"`
-	FieldsToUpdate []string               `yaml:"update_always_fields" json:"update_always_fields"`
+	Priority          string                 `yaml:"priority" json:"priority"`
+	Description       string                 `yaml:"description" json:"description"`
+	WontFixResolution string                 `yaml:"wont_fix_resolution" json:"wont_fix_resolution"`
+	Fields            map[string]interface{} `yaml:"fields" json:"fields"`
+	Components        []string               `yaml:"components" json:"components"`
+	StaticLabels      []string               `yaml:"static_labels" json:"static_labels"`
+	FieldsToUpdate    []string               `yaml:"update_always_fields" json:"update_always_fields"`
 
 	// Label copy settings
 	AddGroupLabels *bool `yaml:"add_group_labels" json:"add_group_labels"`
@@ -313,8 +313,8 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				}
 			}
 		}
-		if len(c.Defaults.CustomFieldsToUpdate) > 0 {
-			rc.CustomFieldsToUpdate = c.Defaults.CustomFieldsToUpdate
+		if len(c.Defaults.FieldsToUpdate) > 0 {
+			rc.FieldsToUpdate = c.Defaults.FieldsToUpdate
 		}
 		if len(c.Defaults.StaticLabels) > 0 {
 			rc.StaticLabels = append(rc.StaticLabels, c.Defaults.StaticLabels...)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -140,12 +140,13 @@ type ReceiverConfig struct {
 	ReopenDuration *Duration `yaml:"reopen_duration" json:"reopen_duration"`
 
 	// Optional issue fields
-	Priority          string                 `yaml:"priority" json:"priority"`
-	Description       string                 `yaml:"description" json:"description"`
-	WontFixResolution string                 `yaml:"wont_fix_resolution" json:"wont_fix_resolution"`
-	Fields            map[string]interface{} `yaml:"fields" json:"fields"`
-	Components        []string               `yaml:"components" json:"components"`
-	StaticLabels      []string               `yaml:"static_labels" json:"static_labels"`
+	Priority             string                 `yaml:"priority" json:"priority"`
+	Description          string                 `yaml:"description" json:"description"`
+	WontFixResolution    string                 `yaml:"wont_fix_resolution" json:"wont_fix_resolution"`
+	Fields               map[string]interface{} `yaml:"fields" json:"fields"`
+	Components           []string               `yaml:"components" json:"components"`
+	StaticLabels         []string               `yaml:"static_labels" json:"static_labels"`
+	CustomFieldsToUpdate []string               `yaml:"update_always_fields" json:"update_always_fields"`
 
 	// Label copy settings
 	AddGroupLabels *bool `yaml:"add_group_labels" json:"add_group_labels"`
@@ -311,6 +312,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 					rc.Fields[key] = value
 				}
 			}
+		}
+		if len(c.Defaults.CustomFieldsToUpdate) > 0 {
+			rc.CustomFieldsToUpdate = c.Defaults.CustomFieldsToUpdate
 		}
 		if len(c.Defaults.StaticLabels) > 0 {
 			rc.StaticLabels = append(rc.StaticLabels, c.Defaults.StaticLabels...)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -76,6 +76,10 @@ receivers:
       customfield_10002: { "value": "red" }
       # MultiSelect
       customfield_10003: [{"value": "red" }, {"value": "blue" }, {"value": "green" }]
+    # List of standard or custom field names which values will be updated. Optional.
+    update_always_fields:
+      - customfield_10001
+      - customfield_10003
 
 # File containing template definitions. Required.
 template: jiralert.tmpl
@@ -126,12 +130,13 @@ type receiverTestConfig struct {
 	ReopenState         string `yaml:"reopen_state,omitempty"`
 	ReopenDuration      string `yaml:"reopen_duration,omitempty"`
 
-	Priority          string   `yaml:"priority,omitempty"`
-	Description       string   `yaml:"description,omitempty"`
-	WontFixResolution string   `yaml:"wont_fix_resolution,omitempty"`
-	AddGroupLabels    *bool    `yaml:"add_group_labels,omitempty"`
+	Priority             string   `yaml:"priority,omitempty"`
+	Description          string   `yaml:"description,omitempty"`
+	WontFixResolution    string   `yaml:"wont_fix_resolution,omitempty"`
+	AddGroupLabels       *bool    `yaml:"add_group_labels,omitempty"`
 	UpdateInComment   *bool    `yaml:"update_in_comment,omitempty"`
-	StaticLabels      []string `yaml:"static_labels" json:"static_labels"`
+	StaticLabels         []string `yaml:"static_labels" json:"static_labels"`
+	CustomFieldsToUpdate []string `yaml:"update_always_fields,omitempty"`
 
 	AutoResolve *AutoResolve `yaml:"auto_resolve" json:"auto_resolve"`
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -134,7 +134,7 @@ type receiverTestConfig struct {
 	Description          string   `yaml:"description,omitempty"`
 	WontFixResolution    string   `yaml:"wont_fix_resolution,omitempty"`
 	AddGroupLabels       *bool    `yaml:"add_group_labels,omitempty"`
-	UpdateInComment   *bool    `yaml:"update_in_comment,omitempty"`
+	UpdateInComment      *bool    `yaml:"update_in_comment,omitempty"`
 	StaticLabels         []string `yaml:"static_labels" json:"static_labels"`
 	CustomFieldsToUpdate []string `yaml:"update_always_fields,omitempty"`
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -130,13 +130,13 @@ type receiverTestConfig struct {
 	ReopenState         string `yaml:"reopen_state,omitempty"`
 	ReopenDuration      string `yaml:"reopen_duration,omitempty"`
 
-	Priority             string   `yaml:"priority,omitempty"`
-	Description          string   `yaml:"description,omitempty"`
-	WontFixResolution    string   `yaml:"wont_fix_resolution,omitempty"`
-	AddGroupLabels       *bool    `yaml:"add_group_labels,omitempty"`
-	UpdateInComment      *bool    `yaml:"update_in_comment,omitempty"`
-	StaticLabels         []string `yaml:"static_labels" json:"static_labels"`
-	FieldsToUpdate []string `yaml:"update_always_fields,omitempty"`
+	Priority          string   `yaml:"priority,omitempty"`
+	Description       string   `yaml:"description,omitempty"`
+	WontFixResolution string   `yaml:"wont_fix_resolution,omitempty"`
+	AddGroupLabels    *bool    `yaml:"add_group_labels,omitempty"`
+	UpdateInComment   *bool    `yaml:"update_in_comment,omitempty"`
+	StaticLabels      []string `yaml:"static_labels" json:"static_labels"`
+	FieldsToUpdate    []string `yaml:"update_always_fields,omitempty"`
 
 	AutoResolve *AutoResolve `yaml:"auto_resolve" json:"auto_resolve"`
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -136,7 +136,7 @@ type receiverTestConfig struct {
 	AddGroupLabels       *bool    `yaml:"add_group_labels,omitempty"`
 	UpdateInComment      *bool    `yaml:"update_in_comment,omitempty"`
 	StaticLabels         []string `yaml:"static_labels" json:"static_labels"`
-	CustomFieldsToUpdate []string `yaml:"update_always_fields,omitempty"`
+	FieldsToUpdate []string `yaml:"update_always_fields,omitempty"`
 
 	AutoResolve *AutoResolve `yaml:"auto_resolve" json:"auto_resolve"`
 

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -146,7 +146,7 @@ func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool, updateSum
 			}
 		}
 
-		for CustomField := range issueCustomFields {
+		for field := range issueCustomFields {
 			if _, ok := issue.Fields.Unknowns[CustomField]; ok {
 				if issue.Fields.Unknowns[CustomField] != issueCustomFields[CustomField] {
 					retry, err = r.updateUnknownFields(issue.Key, tcontainer.MarshalMap(map[string]interface{}{

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -147,7 +147,6 @@ func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool, updateSum
 			}
 		}
 
-
 		for CustomField := range issueCustomFields {
 			if _, ok := issue.Fields.Unknowns[CustomField]; ok {
 				if issue.Fields.Unknowns[CustomField] != issueCustomFields[CustomField] {
@@ -345,7 +344,7 @@ func (r *Receiver) search(projects []string, issueLabel string) (*jira.Issue, bo
 	projectList := "'" + strings.Join(projects, "', '") + "'"
 	query := fmt.Sprintf("project in(%s) and labels=%q order by resolutiondate desc", projectList, issueLabel)
 	options := &jira.SearchOptions{
-		Fields: append([]string{"summary", "status", "resolution", "resolutiondate", "description", "comment"}, r.conf.CustomFieldsToUpdate...),
+		Fields:     append([]string{"summary", "status", "resolution", "resolutiondate", "description", "comment"}, r.conf.CustomFieldsToUpdate...),
 		MaxResults: 2,
 	}
 

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -93,7 +93,7 @@ func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool, updateSum
 
 	issueCustomFields := tcontainer.NewMarshalMap()
 
-	for _, field := range r.conf.CustomFieldsToUpdate {
+	for _, field := range r.conf.FieldsToUpdate {
 		if _, ok := r.conf.Fields[field]; ok {
 			issueCustomFields[field], err = deepCopyWithTemplate(r.conf.Fields[field], r.tmpl, data)
 			if err != nil {
@@ -147,10 +147,10 @@ func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool, updateSum
 		}
 
 		for field := range issueCustomFields {
-			if _, ok := issue.Fields.Unknowns[CustomField]; ok {
-				if issue.Fields.Unknowns[CustomField] != issueCustomFields[CustomField] {
+			if _, ok := issue.Fields.Unknowns[field]; ok {
+				if issue.Fields.Unknowns[field] != issueCustomFields[field] {
 					retry, err = r.updateUnknownFields(issue.Key, tcontainer.MarshalMap(map[string]interface{}{
-						CustomField: issueCustomFields[CustomField],
+						field: issueCustomFields[field],
 					}))
 					if err != nil {
 						return retry, err
@@ -340,7 +340,7 @@ func (r *Receiver) search(projects []string, issueLabel string) (*jira.Issue, bo
 	projectList := "'" + strings.Join(projects, "', '") + "'"
 	query := fmt.Sprintf("project in(%s) and labels=%q order by resolutiondate desc", projectList, issueLabel)
 	options := &jira.SearchOptions{
-		Fields:     append([]string{"summary", "status", "resolution", "resolutiondate", "description", "comment"}, r.conf.CustomFieldsToUpdate...),
+		Fields:     append([]string{"summary", "status", "resolution", "resolutiondate", "description", "comment"}, r.conf.FieldsToUpdate...),
 		MaxResults: 2,
 	}
 

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -157,9 +157,6 @@ func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool, updateSum
 						return retry, err
 					}
 				}
-				if err != nil {
-					return false, err
-				}
 			}
 		}
 

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -94,8 +94,7 @@ func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool, updateSum
 	issueCustomFields := tcontainer.NewMarshalMap()
 
 	for _, field := range r.conf.CustomFieldsToUpdate {
-		_, ok := r.conf.Fields[field]
-		if ok {
+		if _, ok := r.conf.Fields[field]; ok {
 			issueCustomFields[field], err = deepCopyWithTemplate(r.conf.Fields[field], r.tmpl, data)
 			if err != nil {
 				return false, errors.Wrap(err, "render issue fields")

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -451,9 +451,8 @@ func (r *Receiver) updateUnknownFields(issueKey string, unknowns tcontainer.Mars
 			Unknowns: unknowns,
 		},
 	}
-	_, resp, err := r.client.UpdateWithOptions(issueUpdate, nil)
-	if err != nil {
-		return handleJiraErrResponse("Issue.UpdateWithOptions", resp, err, r.logger)
+	if _, resp, err := r.client.UpdateWithOptions(issueUpdate, nil); err != nil {
+		return handleJiraErrResponse("Issue.UpdateUnknownFields", resp, err, r.logger)
 	}
 	return false, nil
 }

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -394,8 +394,7 @@ func TestNotify_JIRAInteraction(t *testing.T) {
 						Annotations: alertmanager.KV{
 							"AlertValue": "95",
 						},
-					},
-					//{Status: "not firing"},
+					}, // New value for the field
 				},
 				Status:      alertmanager.AlertFiring,
 				GroupLabels: alertmanager.KV{"a": "b", "c": "d"},

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -238,7 +238,7 @@ func testReceiverConfigWithCustomFields() *config.ReceiverConfig {
 		Fields: tcontainer.MarshalMap(map[string]interface{}{
 			"customfield_12345": `{{ (index .Alerts 0).Annotations.AlertValue }}`,
 		}),
-		CustomFieldsToUpdate: []string{"customfield_12345","non_existant_field"},
+		CustomFieldsToUpdate: []string{"customfield_12345", "non_existant_field"},
 	}
 }
 

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -56,6 +56,7 @@ func (f *fakeJira) Search(jql string, options *jira.SearchOptions) ([]jira.Issue
 	var issues []jira.Issue
 	for _, key := range f.keysByQuery[jql] {
 		issue := jira.Issue{Key: key, Fields: &jira.IssueFields{}}
+		issue.Fields.Unknowns = f.issuesByKey[key].Fields.Unknowns
 		for _, field := range options.Fields {
 			switch field {
 			case "summary":
@@ -130,6 +131,10 @@ func (f *fakeJira) UpdateWithOptions(old *jira.Issue, _ *jira.UpdateQueryOptions
 
 	if old.Fields.Description != "" {
 		issue.Fields.Description = old.Fields.Description
+	}
+
+	if old.Fields.Unknowns != nil {
+		issue.Fields.Unknowns = old.Fields.Unknowns
 	}
 
 	f.issuesByKey[issue.Key] = issue
@@ -219,6 +224,21 @@ func testReceiverConfigWithStaticLabels() *config.ReceiverConfig {
 		ReopenState:       "reopened",
 		WontFixResolution: "won't-fix",
 		StaticLabels:      []string{"somelabel"},
+	}
+}
+
+func testReceiverConfigWithCustomFields() *config.ReceiverConfig {
+	reopen := config.Duration(1 * time.Hour)
+	return &config.ReceiverConfig{
+		Project:        "abc",
+		Summary:        `[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }} {{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}`,
+		ReopenDuration: &reopen,
+		ReopenState:    "reopened",
+		Description:    `{{ .Alerts.Firing | len }}`,
+		Fields: tcontainer.MarshalMap(map[string]interface{}{
+			"customfield_12345": `{{ (index .Alerts 0).Annotations.AlertValue }}`,
+		}),
+		CustomFieldsToUpdate: []string{"customfield_12345","non_existant_field"},
 	}
 }
 
@@ -342,6 +362,58 @@ func TestNotify_JIRAInteraction(t *testing.T) {
 						},
 						Unknowns:    tcontainer.MarshalMap{},
 						Summary:     "[FIRING:1] b d ", // Title changed.
+						Description: "1",
+					},
+				},
+			},
+		},
+		{
+			name:        "opened ticket, update specified custom field value",
+			inputConfig: testReceiverConfigWithCustomFields(),
+			initJira: func(t *testing.T) *fakeJira {
+				f := newTestFakeJira()
+				_, _, err := f.Create(&jira.Issue{
+					ID:  "1",
+					Key: "1",
+					Fields: &jira.IssueFields{
+						Project: jira.Project{Key: testReceiverConfigWithCustomFields().Project},
+						Labels:  []string{"JIRALERT{819ba5ecba4ea5946a8d17d285cb23f3bb6862e08bb602ab08fd231cd8e1a83a1d095b0208a661787e9035f0541817634df5a994d1b5d4200d6c68a7663c97f5}"},
+						Unknowns: tcontainer.MarshalMap(map[string]interface{}{
+							"customfield_12345": "90",
+						}),
+						Summary:     "[FIRING:1] b d ",
+						Description: "1",
+					},
+				})
+				require.NoError(t, err)
+				return f
+			},
+			inputAlert: &alertmanager.Data{
+				Alerts: alertmanager.Alerts{
+					{Status: alertmanager.AlertFiring,
+						Annotations: alertmanager.KV{
+							"AlertValue": "95",
+						},
+					},
+					//{Status: "not firing"},
+				},
+				Status:      alertmanager.AlertFiring,
+				GroupLabels: alertmanager.KV{"a": "b", "c": "d"},
+			},
+			expectedJiraIssues: map[string]*jira.Issue{
+				"1": {
+					ID:  "1",
+					Key: "1",
+					Fields: &jira.IssueFields{
+						Project: jira.Project{Key: testReceiverConfigWithCustomFields().Project},
+						Labels:  []string{"JIRALERT{819ba5ecba4ea5946a8d17d285cb23f3bb6862e08bb602ab08fd231cd8e1a83a1d095b0208a661787e9035f0541817634df5a994d1b5d4200d6c68a7663c97f5}"},
+						Status: &jira.Status{
+							StatusCategory: jira.StatusCategory{Key: "NotDone"},
+						},
+						Unknowns: tcontainer.MarshalMap{
+							"customfield_12345": "95",
+						},
+						Summary:     "[FIRING:1] b d ",
 						Description: "1",
 					},
 				},

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -238,7 +238,7 @@ func testReceiverConfigWithCustomFields() *config.ReceiverConfig {
 		Fields: tcontainer.MarshalMap(map[string]interface{}{
 			"customfield_12345": `{{ (index .Alerts 0).Annotations.AlertValue }}`,
 		}),
-		CustomFieldsToUpdate: []string{"customfield_12345", "non_existant_field"},
+		FieldsToUpdate: []string{"customfield_12345", "non_existant_field"},
 	}
 }
 


### PR DESCRIPTION
Could anyone please review this pr?

It is backward compatible, as by default it does nothing, only in a way that feature might interfere with the logic of (https://github.com/prometheus-community/jiralert/pull/150) as it might still update some values even if `updateSummary` and `updateDescription` flags are disabled. 

If that is ok, I could move these `updateSummary`,  `updateDescription` and `reopenTickets` flags to the config to make it more flexible and allow "per-receiver" configs rather than global flags.

Resolves #157