### PR TITLE
add ability to update in comments

### DIFF
--- a/cmd/jiralert/main.go
+++ b/cmd/jiralert/main.go
@@ -36,9 +36,10 @@ import (
 )
 
 const (
-	unknownReceiver = "<unknown>"
-	logFormatLogfmt = "logfmt"
-	logFormatJSON   = "json"
+	unknownReceiver             = "<unknown>"
+	logFormatLogfmt             = "logfmt"
+	logFormatJSON               = "json"
+	defaultMaxDescriptionLength = 32767 // https://jira.atlassian.com/browse/JRASERVER-64351
 )
 
 var (
@@ -48,9 +49,10 @@ var (
 	logFormat     = flag.String("log.format", logFormatLogfmt, "Log format to use ("+logFormatLogfmt+", "+logFormatJSON+")")
 	hashJiraLabel = flag.Bool("hash-jira-label", false, "if enabled: renames ALERT{...} to JIRALERT{...}; also hashes the key-value pairs inside of JIRALERT{...} in the created jira issue labels"+
 		"- this ensures that the label text does not overflow the allowed length in jira (255)")
-	updateSummary     = flag.Bool("update-summary", true, "When false, jiralert does not update the summary of the existing jira issue, even when changes are spotted.")
-	updateDescription = flag.Bool("update-description", true, "When false, jiralert does not update the description of the existing jira issue, even when changes are spotted.")
-	reopenTickets     = flag.Bool("reopen-tickets", true, "When false, jiralert does not reopen tickets.")
+	updateSummary        = flag.Bool("update-summary", true, "When false, jiralert does not update the summary of the existing jira issue, even when changes are spotted.")
+	updateDescription    = flag.Bool("update-description", true, "When false, jiralert does not update the description of the existing jira issue, even when changes are spotted.")
+	reopenTickets        = flag.Bool("reopen-tickets", true, "When false, jiralert does not reopen tickets.")
+	maxDescriptionLength = flag.Int("max-description-length", defaultMaxDescriptionLength, "Maximum length of Descriptions. Truncate to this size avoid server errors.")
 
 	// Version is the build version, set by make to latest git tag/hash via `-ldflags "-X main.Version=$(VERSION)"`.
 	Version = "<local build>"
@@ -124,7 +126,7 @@ func main() {
 			return
 		}
 
-		if retry, err := notify.NewReceiver(logger, conf, tmpl, client.Issue).Notify(&data, *hashJiraLabel, *updateSummary, *updateDescription, *reopenTickets); err != nil {
+		if retry, err := notify.NewReceiver(logger, conf, tmpl, client.Issue).Notify(&data, *hashJiraLabel, *updateSummary, *updateDescription, *reopenTickets, *maxDescriptionLength); err != nil {
 			var status int
 			if retry {
 				// Instruct Alertmanager to retry.

--- a/cmd/jiralert/main.go
+++ b/cmd/jiralert/main.go
@@ -50,7 +50,6 @@ var (
 		"- this ensures that the label text does not overflow the allowed length in jira (255)")
 	updateSummary     = flag.Bool("update-summary", true, "When false, jiralert does not update the summary of the existing jira issue, even when changes are spotted.")
 	updateDescription = flag.Bool("update-description", true, "When false, jiralert does not update the description of the existing jira issue, even when changes are spotted.")
-	updateInComment   = flag.Bool("update-in-comment", true, "When true, jiralert adds a comment with an update of the existing jira issue.")
 	reopenTickets     = flag.Bool("reopen-tickets", true, "When false, jiralert does not reopen tickets.")
 
 	// Version is the build version, set by make to latest git tag/hash via `-ldflags "-X main.Version=$(VERSION)"`.
@@ -125,7 +124,7 @@ func main() {
 			return
 		}
 
-		if retry, err := notify.NewReceiver(logger, conf, tmpl, client.Issue).Notify(&data, *hashJiraLabel, *updateSummary, *updateDescription, *updateInComment, *reopenTickets); err != nil {
+		if retry, err := notify.NewReceiver(logger, conf, tmpl, client.Issue).Notify(&data, *hashJiraLabel, *updateSummary, *updateDescription, *reopenTickets); err != nil {
 			var status int
 			if retry {
 				// Instruct Alertmanager to retry.

--- a/cmd/jiralert/main.go
+++ b/cmd/jiralert/main.go
@@ -50,6 +50,7 @@ var (
 		"- this ensures that the label text does not overflow the allowed length in jira (255)")
 	updateSummary     = flag.Bool("update-summary", true, "When false, jiralert does not update the summary of the existing jira issue, even when changes are spotted.")
 	updateDescription = flag.Bool("update-description", true, "When false, jiralert does not update the description of the existing jira issue, even when changes are spotted.")
+	updateInComment   = flag.Bool("update-in-comment", true, "When true, jiralert adds a comment with an update of the existing jira issue.")
 	reopenTickets     = flag.Bool("reopen-tickets", true, "When false, jiralert does not reopen tickets.")
 
 	// Version is the build version, set by make to latest git tag/hash via `-ldflags "-X main.Version=$(VERSION)"`.
@@ -124,7 +125,7 @@ func main() {
 			return
 		}
 
-		if retry, err := notify.NewReceiver(logger, conf, tmpl, client.Issue).Notify(&data, *hashJiraLabel, *updateSummary, *updateDescription, *reopenTickets); err != nil {
+		if retry, err := notify.NewReceiver(logger, conf, tmpl, client.Issue).Notify(&data, *hashJiraLabel, *updateSummary, *updateDescription, *updateInComment, *reopenTickets); err != nil {
 			var status int
 			if retry {
 				// Instruct Alertmanager to retry.

--- a/examples/jiralert.yml
+++ b/examples/jiralert.yml
@@ -34,6 +34,8 @@ receivers:
     project: AB
     # Copy all Prometheus labels into separate JIRA labels. Optional (default: false).
     add_group_labels: false
+    # Include ticket update as comment too. Optional (default: false).
+    update_in_comment: false
     # Will be merged with the static_labels from the default map
     static_labels: ["anotherLabel"]
 

--- a/examples/jiralert.yml
+++ b/examples/jiralert.yml
@@ -34,8 +34,6 @@ receivers:
     project: AB
     # Copy all Prometheus labels into separate JIRA labels. Optional (default: false).
     add_group_labels: false
-    # Include ticket update as comment too. Optional (default: false).
-    update_in_comment: false
     # Will be merged with the static_labels from the default map
     static_labels: ["anotherLabel"]
 
@@ -58,7 +56,9 @@ receivers:
     #
     # Automatically resolve jira issues when alert is resolved. Optional. If declared, ensure state is not an empty string.
     auto_resolve:
-      state: 'Done' 
+      state: 'Done'
+    # Include ticket update as comment. Optional (default: false).
+    update_in_comment: false
 
 # File containing template definitions. Required.
 template: jiralert.tmpl

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -150,6 +150,9 @@ type ReceiverConfig struct {
 	AddGroupLabels bool `yaml:"add_group_labels" json:"add_group_labels"`
 
 	// Flag to auto-resolve opened issue when the alert is resolved.
+	UpdateInComment bool `yaml:"update_in_comment" json:"update_in_comment"`
+
+	// Flag to auto-resolve opened issue when the alert is resolved.
 	AutoResolve *AutoResolve `yaml:"auto_resolve" json:"auto_resolve"`
 
 	// Catches all undefined fields and must be empty after parsing.
@@ -311,6 +314,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if len(c.Defaults.StaticLabels) > 0 {
 			rc.StaticLabels = append(rc.StaticLabels, c.Defaults.StaticLabels...)
 		}
+    if ! rc.UpdateInComment {
+      rc.UpdateInComment = c.Defaults.UpdateInComment
+    }
 	}
 
 	if len(c.Receivers) == 0 {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -149,7 +149,7 @@ type ReceiverConfig struct {
 	// Label copy settings
 	AddGroupLabels bool `yaml:"add_group_labels" json:"add_group_labels"`
 
-	// Flag to auto-resolve opened issue when the alert is resolved.
+	// Flag to enable updates in comments.
 	UpdateInComment bool `yaml:"update_in_comment" json:"update_in_comment"`
 
 	// Flag to auto-resolve opened issue when the alert is resolved.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -314,9 +314,6 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if len(c.Defaults.StaticLabels) > 0 {
 			rc.StaticLabels = append(rc.StaticLabels, c.Defaults.StaticLabels...)
 		}
-    if ! rc.UpdateInComment {
-      rc.UpdateInComment = c.Defaults.UpdateInComment
-    }
 	}
 
 	if len(c.Receivers) == 0 {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -388,7 +388,7 @@ func newReceiverTestConfig(mandatory []string, optional []string) *receiverTestC
 		var value reflect.Value
 		if name == "AddGroupLabels" {
 			value = reflect.ValueOf(true)
-    } else if name == "UpdateInComment" {
+		} else if name == "UpdateInComment" {
 			value = reflect.ValueOf(true)
 		} else if name == "AutoResolve" {
 			value = reflect.ValueOf(&AutoResolve{State: "Done"})

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -56,6 +56,7 @@ receivers:
     project: AB
     # Copy all Prometheus labels into separate JIRA labels. Optional (default: false).
     add_group_labels: false
+    update_in_comment: false
     static_labels: ["somelabel"]
 
   - name: 'jira-xy'
@@ -128,6 +129,7 @@ type receiverTestConfig struct {
 	Description       string   `yaml:"description,omitempty"`
 	WontFixResolution string   `yaml:"wont_fix_resolution,omitempty"`
 	AddGroupLabels    bool     `yaml:"add_group_labels,omitempty"`
+	UpdateInComment   bool     `yaml:"update_in_comment,omitempty"`
 	StaticLabels      []string `yaml:"static_labels" json:"static_labels"`
 
 	AutoResolve *AutoResolve `yaml:"auto_resolve" json:"auto_resolve"`
@@ -330,10 +332,11 @@ func TestReceiverOverrides(t *testing.T) {
 		{"Description", "A nice description", "A nice description"},
 		{"WontFixResolution", "Won't Fix", "Won't Fix"},
 		{"AddGroupLabels", false, false},
+		{"UpdateInComment", false, false},
 		{"AutoResolve", &AutoResolve{State: "Done"}, &autoResolve},
 		{"StaticLabels", []string{"somelabel"}, []string{"somelabel"}},
 	} {
-		optionalFields := []string{"Priority", "Description", "WontFixResolution", "AddGroupLabels", "AutoResolve", "StaticLabels"}
+		optionalFields := []string{"Priority", "Description", "WontFixResolution", "AddGroupLabels", "UpdateInComment", "AutoResolve", "StaticLabels"}
 		defaultsConfig := newReceiverTestConfig(mandatoryReceiverFields(), optionalFields)
 		receiverConfig := newReceiverTestConfig([]string{"Name"}, optionalFields)
 
@@ -384,6 +387,8 @@ func newReceiverTestConfig(mandatory []string, optional []string) *receiverTestC
 	for _, name := range optional {
 		var value reflect.Value
 		if name == "AddGroupLabels" {
+			value = reflect.ValueOf(true)
+    } else if name == "UpdateInComment" {
 			value = reflect.ValueOf(true)
 		} else if name == "AutoResolve" {
 			value = reflect.ValueOf(&AutoResolve{State: "Done"})

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -333,10 +333,11 @@ func TestReceiverOverrides(t *testing.T) {
 		{"WontFixResolution", "Won't Fix", "Won't Fix"},
 		{"AddGroupLabels", false, false},
 		{"UpdateInComment", false, false},
+		{"UpdateInComment", true, true},
 		{"AutoResolve", &AutoResolve{State: "Done"}, &autoResolve},
 		{"StaticLabels", []string{"somelabel"}, []string{"somelabel"}},
 	} {
-		optionalFields := []string{"Priority", "Description", "WontFixResolution", "AddGroupLabels", "UpdateInComment", "AutoResolve", "StaticLabels"}
+		optionalFields := []string{"Priority", "Description", "WontFixResolution", "AddGroupLabels", "AutoResolve", "StaticLabels"}
 		defaultsConfig := newReceiverTestConfig(mandatoryReceiverFields(), optionalFields)
 		receiverConfig := newReceiverTestConfig([]string{"Name"}, optionalFields)
 
@@ -387,8 +388,6 @@ func newReceiverTestConfig(mandatory []string, optional []string) *receiverTestC
 	for _, name := range optional {
 		var value reflect.Value
 		if name == "AddGroupLabels" {
-			value = reflect.ValueOf(true)
-		} else if name == "UpdateInComment" {
 			value = reflect.ValueOf(true)
 		} else if name == "AutoResolve" {
 			value = reflect.ValueOf(&AutoResolve{State: "Done"})

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -61,7 +61,7 @@ func NewReceiver(logger log.Logger, c *config.ReceiverConfig, t *template.Templa
 }
 
 // Notify manages JIRA issues based on alertmanager webhook notify message.
-func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool, updateSummary bool, updateDescription bool, reopenTickets bool) (bool, error) {
+func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool, updateSummary bool, updateDescription bool, reopenTickets bool, maxDescriptionLength int) (bool, error) {
 	project, err := r.tmpl.Execute(r.conf.Project, data)
 	if err != nil {
 		return false, errors.Wrap(err, "generate project from template")
@@ -84,6 +84,11 @@ func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool, updateSum
 	issueDesc, err := r.tmpl.Execute(r.conf.Description, data)
 	if err != nil {
 		return false, errors.Wrap(err, "render issue description")
+	}
+
+	if len(issueDesc) > maxDescriptionLength {
+		level.Warn(r.logger).Log("msg", "truncating description", "original", len(issueDesc), "limit", maxDescriptionLength)
+		issueDesc = issueDesc[:maxDescriptionLength]
 	}
 
 	if issue != nil {

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -61,7 +61,7 @@ func NewReceiver(logger log.Logger, c *config.ReceiverConfig, t *template.Templa
 }
 
 // Notify manages JIRA issues based on alertmanager webhook notify message.
-func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool, updateSummary bool, updateDescription bool, updateInComment bool, reopenTickets bool) (bool, error) {
+func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool, updateSummary bool, updateDescription bool, reopenTickets bool) (bool, error) {
 	project, err := r.tmpl.Execute(r.conf.Project, data)
 	if err != nil {
 		return false, errors.Wrap(err, "generate project from template")
@@ -108,7 +108,7 @@ func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool, updateSum
 			}
 		}
 
-		if updateInComment {
+		if r.conf.UpdateInComment {
 			retry, err := r.addComment(issue.Key, issueDesc)
 			if err != nil {
 				return retry, err

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -597,7 +597,7 @@ func TestNotify_JIRAInteraction(t *testing.T) {
 				return testNowTime
 			}
 
-			_, err := receiver.Notify(tcase.inputAlert, true, true, true, false, true)
+			_, err := receiver.Notify(tcase.inputAlert, true, true, true, true)
 			require.NoError(t, err)
 			require.Equal(t, tcase.expectedJiraIssues, fakeJira.issuesByKey)
 		}); !ok {

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -597,7 +597,7 @@ func TestNotify_JIRAInteraction(t *testing.T) {
 				return testNowTime
 			}
 
-			_, err := receiver.Notify(tcase.inputAlert, true, true, true, true)
+			_, err := receiver.Notify(tcase.inputAlert, true, true, true, true, 32768)
 			require.NoError(t, err)
 			require.Equal(t, tcase.expectedJiraIssues, fakeJira.issuesByKey)
 		}); !ok {

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -134,6 +134,11 @@ func (f *fakeJira) UpdateWithOptions(old *jira.Issue, _ *jira.UpdateQueryOptions
 	return issue, nil, nil
 }
 
+func (f *fakeJira) AddComment(issueID string, comment *jira.Comment) (*jira.Comment, *jira.Response, error) {
+	// This is a placeholder to keep fakeJira compatible with the updated Interface
+	return nil, nil, nil
+}
+
 func (f *fakeJira) DoTransition(ticketID, transitionID string) (*jira.Response, error) {
 	issue, ok := f.issuesByKey[ticketID]
 	if !ok {
@@ -592,7 +597,7 @@ func TestNotify_JIRAInteraction(t *testing.T) {
 				return testNowTime
 			}
 
-			_, err := receiver.Notify(tcase.inputAlert, true, true, true, true)
+			_, err := receiver.Notify(tcase.inputAlert, true, true, true, false, true)
 			require.NoError(t, err)
 			require.Equal(t, tcase.expectedJiraIssues, fakeJira.issuesByKey)
 		}); !ok {


### PR DESCRIPTION
As an alternative, or as an addition to updated the Description, additional Alert updates should go to comments.

The default behavior is to update the JIRA Description when the Alert details change. This makes it difficult if the viewers of the JIRA are researching each failure because it is not obvious which alerts are new or existing. Depending on the Alert expression, old firing details may also be removed.

Additionally, adding too many firing details to the description increases the likelihood of exceeding the 32KB char limit for the JIRA Description.

By optionally sending each update to a Comment, viewers can better keep track of which activity is new, and it will be possible to continue adding firing details without exceeding the Description char limit.

resolves #160 