### PR TITLE
search for existing issue in multiple projects

### DIFF
--- a/examples/jiralert.yml
+++ b/examples/jiralert.yml
@@ -25,6 +25,8 @@ defaults:
   reopen_duration: 0h
   # Static label that will be added to the JIRA ticket alongisde the JIRALERT{...} or ALERT{...} label
   static_labels: ["custom"]
+  # Other projects that issues may be moved to and further updates are desired
+  other_projects: ["OTHER1", "OTHER2"]
 
 # Receiver definitions. At least one must be defined.
 receivers:
@@ -56,7 +58,7 @@ receivers:
     #
     # Automatically resolve jira issues when alert is resolved. Optional. If declared, ensure state is not an empty string.
     auto_resolve:
-      state: 'Done' 
+      state: 'Done'
 
 # File containing template definitions. Required.
 template: jiralert.tmpl

--- a/examples/jiralert.yml
+++ b/examples/jiralert.yml
@@ -25,7 +25,11 @@ defaults:
   reopen_duration: 0h
   # Static label that will be added to the JIRA ticket alongisde the JIRALERT{...} or ALERT{...} label
   static_labels: ["custom"]
-  # Other projects that issues may be moved to and further updates are desired
+  # Other projects are the projects to search for existing issues for the given alerts if
+  # the main project does not have it. If no issue was found in, the main projects will
+  # be used to create a new one. If the old issue is found in one of the other projects
+  # (first found is used in case of duplicates) that old project's issue will be used for
+  # alert updates instead of creating on in the main project.
   other_projects: ["OTHER1", "OTHER2"]
 
 # Receiver definitions. At least one must be defined.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -133,6 +133,7 @@ type ReceiverConfig struct {
 
 	// Required issue fields
 	Project        string    `yaml:"project" json:"project"`
+	OtherProjects  []string  `yaml:"other_projects" json:"other_projects"`
 	IssueType      string    `yaml:"issue_type" json:"issue_type"`
 	Summary        string    `yaml:"summary" json:"summary"`
 	ReopenState    string    `yaml:"reopen_state" json:"reopen_state"`
@@ -310,6 +311,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 		if len(c.Defaults.StaticLabels) > 0 {
 			rc.StaticLabels = append(rc.StaticLabels, c.Defaults.StaticLabels...)
+		}
+		if len(c.Defaults.OtherProjects) > 0 {
+			rc.OtherProjects = append(rc.OtherProjects, c.Defaults.OtherProjects...)
 		}
 	}
 

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -289,7 +289,7 @@ func toGroupTicketLabel(groupLabels alertmanager.KV, hashJiraLabel bool) string 
 }
 
 func (r *Receiver) search(projects []string, issueLabel string) (*jira.Issue, bool, error) {
-	// search multiple projects in case issue was moved and further alert firings are desired in existing JIRA
+	// Search multiple projects in case issue was moved and further alert firings are desired in existing JIRA.
 	projectList := "'" + strings.Join(projects, "', '") + "'"
 	query := fmt.Sprintf("project in(%s) and labels=%q order by resolutiondate desc", projectList, issueLabel)
 	options := &jira.SearchOptions{
@@ -320,7 +320,7 @@ func (r *Receiver) search(projects []string, issueLabel string) (*jira.Issue, bo
 
 func (r *Receiver) findIssueToReuse(project string, issueGroupLabel string) (*jira.Issue, bool, error) {
 	projectsToSearch := []string{project}
-	// in case issue was moved to a different project, include configured potential other projects in search
+	// In case issue was moved to a different project, include the other configured projects in search (if any).
 	for _, other := range r.conf.OtherProjects {
 		if other != project {
 			projectsToSearch = append(projectsToSearch, other)

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -107,7 +107,7 @@ func (f *fakeJira) Create(issue *jira.Issue) (*jira.Issue, *jira.Response, error
 
 	// Assuming single label.
 	query := fmt.Sprintf(
-		"project=\"%s\" and labels=%q order by resolutiondate desc",
+		"project in('%s') and labels=%q order by resolutiondate desc",
 		issue.Fields.Project.Key,
 		issue.Fields.Labels[0],
 	)


### PR DESCRIPTION
If a JIRAlert-created issue is moved to another project, and the alert fires again, JIRAlert doesn't find the issue because it only searches within the target JIRA project.

This can be a problem if issues are assigned to another team's JIRA project due to the nature of the failure. If the alert fires again, the updates should still go to the existing JIRA, instead of creating a new issue that may also need to be moved.

resolves #159 