### PR TITLE
Add ability to update in comments (now configurable per receiver)

### DIFF
--- a/examples/jiralert.yml
+++ b/examples/jiralert.yml
@@ -31,6 +31,8 @@ defaults:
   # (first found is used in case of duplicates) that old project's issue will be used for
   # alert updates instead of creating on in the main project.
   other_projects: ["OTHER1", "OTHER2"]
+  # Include ticket update as comment. Optional (default: false).
+  update_in_comment: false
 
 # Receiver definitions. At least one must be defined.
 receivers:
@@ -40,6 +42,8 @@ receivers:
     project: AB
     # Copy all Prometheus labels into separate JIRA labels. Optional (default: false).
     add_group_labels: false
+    # Include ticket update as comment too. Optional (default: false).
+    update_in_comment: false
     # Will be merged with the static_labels from the default map
     static_labels: ["anotherLabel"]
 
@@ -63,6 +67,9 @@ receivers:
     # Automatically resolve jira issues when alert is resolved. Optional. If declared, ensure state is not an empty string.
     auto_resolve:
       state: 'Done'
+    # Include ticket update as comment too. Optional (default: false).
+    update_in_comment: true
+
 
 # File containing template definitions. Required.
 template: jiralert.tmpl

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,36 +47,6 @@ func (s *Secret) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return unmarshal((*plain)(s))
 }
 
-// NullBool will be used for boolean configuration values that should not
-// default to false when undefined and the default setting is true.
-type NullBool struct {
-	Bool  bool
-	Valid bool // Valid is true if Bool is defined
-}
-
-// MarshalYAML implements the yaml.Marshaler interface.
-func (nb NullBool) MarshalYAML() (interface{}, error) {
-	if nb.Valid {
-		return nb.Bool, nil
-	}
-	return false, nil
-}
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface
-func (nb *NullBool) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var b bool
-
-	err := unmarshal(&b)
-	if err != nil {
-		return err
-	}
-
-	nb.Bool = b
-	nb.Valid = true
-
-	return nil
-}
-
 // Load parses the YAML input into a Config.
 func Load(s string) (*Config, error) {
 	cfg := &Config{}
@@ -178,10 +148,10 @@ type ReceiverConfig struct {
 	StaticLabels      []string               `yaml:"static_labels" json:"static_labels"`
 
 	// Label copy settings
-	AddGroupLabels bool `yaml:"add_group_labels" json:"add_group_labels"`
+	AddGroupLabels *bool `yaml:"add_group_labels" json:"add_group_labels"`
 
 	// Flag to enable updates in comments.
-	UpdateInComment NullBool `yaml:"update_in_comment" json:"update_in_comment"`
+	UpdateInComment *bool `yaml:"update_in_comment" json:"update_in_comment"`
 
 	// Flag to auto-resolve opened issue when the alert is resolved.
 	AutoResolve *AutoResolve `yaml:"auto_resolve" json:"auto_resolve"`
@@ -348,7 +318,10 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if len(c.Defaults.OtherProjects) > 0 {
 			rc.OtherProjects = append(rc.OtherProjects, c.Defaults.OtherProjects...)
 		}
-		if !rc.UpdateInComment.Valid && c.Defaults.UpdateInComment.Valid {
+		if rc.AddGroupLabels == nil {
+			rc.AddGroupLabels = c.Defaults.AddGroupLabels
+		}
+		if rc.UpdateInComment == nil {
 			rc.UpdateInComment = c.Defaults.UpdateInComment
 		}
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -129,8 +129,8 @@ type receiverTestConfig struct {
 	Priority          string   `yaml:"priority,omitempty"`
 	Description       string   `yaml:"description,omitempty"`
 	WontFixResolution string   `yaml:"wont_fix_resolution,omitempty"`
-	AddGroupLabels    bool     `yaml:"add_group_labels,omitempty"`
-	UpdateInComment   NullBool `yaml:"update_in_comment,omitempty"`
+	AddGroupLabels    *bool    `yaml:"add_group_labels,omitempty"`
+	UpdateInComment   *bool    `yaml:"update_in_comment,omitempty"`
 	StaticLabels      []string `yaml:"static_labels" json:"static_labels"`
 
 	AutoResolve *AutoResolve `yaml:"auto_resolve" json:"auto_resolve"`
@@ -316,6 +316,10 @@ func TestReceiverOverrides(t *testing.T) {
 	fifteenHoursToDuration, err := ParseDuration("15h")
 	autoResolve := AutoResolve{State: "Done"}
 	require.NoError(t, err)
+	addGroupLabelsTrueVal := true
+	addGroupLabelsFalseVal := false
+	updateInCommentTrueVal := true
+	updateInCommentFalseVal := false
 
 	// We'll override one key at a time and check the value in the receiver.
 	for _, test := range []struct {
@@ -332,9 +336,10 @@ func TestReceiverOverrides(t *testing.T) {
 		{"Priority", "Critical", "Critical"},
 		{"Description", "A nice description", "A nice description"},
 		{"WontFixResolution", "Won't Fix", "Won't Fix"},
-		{"AddGroupLabels", false, false},
-		{"UpdateInComment", NullBool{Bool: false, Valid: true}, NullBool{Bool: false, Valid: true}},
-		{"UpdateInComment", NullBool{Bool: true, Valid: true}, NullBool{Bool: true, Valid: true}},
+		{"AddGroupLabels", &addGroupLabelsFalseVal, &addGroupLabelsFalseVal},
+		{"AddGroupLabels", &addGroupLabelsTrueVal, &addGroupLabelsTrueVal},
+		{"UpdateInComment", &updateInCommentFalseVal, &updateInCommentFalseVal},
+		{"UpdateInComment", &updateInCommentTrueVal, &updateInCommentTrueVal},
 		{"AutoResolve", &AutoResolve{State: "Done"}, &autoResolve},
 		{"StaticLabels", []string{"somelabel"}, []string{"somelabel"}},
 	} {
@@ -372,6 +377,8 @@ func TestReceiverOverrides(t *testing.T) {
 // Creates a receiverTestConfig struct with default values.
 func newReceiverTestConfig(mandatory []string, optional []string) *receiverTestConfig {
 	r := receiverTestConfig{}
+	addGroupLabelsDefaultVal := true
+	updateInCommentDefaultVal := true
 
 	for _, name := range mandatory {
 		var value reflect.Value
@@ -389,9 +396,9 @@ func newReceiverTestConfig(mandatory []string, optional []string) *receiverTestC
 	for _, name := range optional {
 		var value reflect.Value
 		if name == "AddGroupLabels" {
-			value = reflect.ValueOf(true)
+			value = reflect.ValueOf(&addGroupLabelsDefaultVal)
 		} else if name == "UpdateInComment" {
-			value = reflect.ValueOf(NullBool{Bool: false, Valid: false})
+			value = reflect.ValueOf(&updateInCommentDefaultVal)
 		} else if name == "AutoResolve" {
 			value = reflect.ValueOf(&AutoResolve{State: "Done"})
 		} else if name == "StaticLabels" {

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -104,7 +104,7 @@ func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool, updateSum
 			}
 		}
 
-		if r.conf.UpdateInComment.Valid && r.conf.UpdateInComment.Bool {
+		if r.conf.UpdateInComment != nil && *r.conf.UpdateInComment {
 			numComments := 0
 			if issue.Fields.Comments != nil {
 				numComments = len(issue.Fields.Comments.Comments)
@@ -215,7 +215,7 @@ func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool, updateSum
 		}
 	}
 
-	if r.conf.AddGroupLabels {
+	if r.conf.AddGroupLabels != nil && *r.conf.AddGroupLabels {
 		for k, v := range data.GroupLabels {
 			issue.Fields.Labels = append(issue.Fields.Labels, fmt.Sprintf("%s=%.200q", k, v))
 		}

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -125,7 +125,7 @@ func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool, updateSum
 			}
 		}
 
-		// update description after possibly adding a comment so that it's possible to detect redundant first comment
+		// update description if enabled. This has to be done after comment adding logic which needs to handle redundant commentary vs description case.
 		if updateDescription {
 			if issue.Fields.Description != issueDesc {
 				retry, err := r.updateDescription(issue.Key, issueDesc)

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -185,6 +185,7 @@ func testReceiverConfig2() *config.ReceiverConfig {
 
 func testReceiverConfigAddComments() *config.ReceiverConfig {
 	reopen := config.Duration(1 * time.Hour)
+	updateInCommentValue := true
 	return &config.ReceiverConfig{
 		Project:           "abc",
 		Summary:           `[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }} {{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}`,
@@ -192,7 +193,7 @@ func testReceiverConfigAddComments() *config.ReceiverConfig {
 		ReopenState:       "reopened",
 		Description:       `{{ .Alerts.Firing | len }}`,
 		WontFixResolution: "won't-fix",
-		UpdateInComment:   config.NullBool{Valid: true, Bool: true},
+		UpdateInComment:   &updateInCommentValue,
 	}
 }
 


### PR DESCRIPTION
As an alternative, or as an addition to updating the Description, additional Alert updates should go to comments.

The default behavior is to update the JIRA Description when the Alert details change. This makes it difficult if the viewers of the JIRA are researching each failure because it is not obvious which alerts are new or existing. Depending on the Alert expression, old firing details may also be removed.

Additionally, adding too many firing details to the description increases the likelihood of exceeding the 32KB char limit for the JIRA Description.

By optionally sending each update to a Comment, viewers can better keep track of which activity is new, and it will be possible to continue adding firing details without exceeding the Description char limit.

resolves https://github.com/prometheus-community/jiralert/issues/160
