### PR TITLE
add support for multiple templates in config

### DIFF
--- a/examples/jiralert.yml
+++ b/examples/jiralert.yml
@@ -72,4 +72,6 @@ receivers:
 
 
 # File containing template definitions. Required.
-template: jiralert.tmpl
+template:
+- jiralert.tmpl
+- other.tmpl

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -112,7 +112,9 @@ func resolveFilepaths(baseDir string, cfg *Config, logger log.Logger) {
 		return absFp
 	}
 
-	cfg.Template = join(cfg.Template)
+	for i, v := range cfg.Template {
+		cfg.Template[i] = join(v)
+	}
 }
 
 // AutoResolve is the struct used for defining jira resolution state when alert is resolved.
@@ -180,7 +182,7 @@ func (rc *ReceiverConfig) UnmarshalYAML(unmarshal func(interface{}) error) error
 type Config struct {
 	Defaults  *ReceiverConfig   `yaml:"defaults,omitempty" json:"defaults,omitempty"`
 	Receivers []*ReceiverConfig `yaml:"receivers,omitempty" json:"receivers,omitempty"`
-	Template  string            `yaml:"template" json:"template"`
+	Template  []string          `yaml:"template" json:"template"`
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`
@@ -330,7 +332,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return fmt.Errorf("no receivers defined")
 	}
 
-	if c.Template == "" {
+	if len(c.Template) == 0 {
 		return fmt.Errorf("missing template file")
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -78,7 +78,7 @@ receivers:
       customfield_10003: [{"value": "red" }, {"value": "blue" }, {"value": "green" }]
 
 # File containing template definitions. Required.
-template: jiralert.tmpl
+template: ["jiralert.tmpl"]
 `
 
 // Generic test that loads the testConf with no errors.
@@ -144,7 +144,7 @@ type receiverTestConfig struct {
 type testConfig struct {
 	Defaults  *receiverTestConfig   `yaml:"defaults,omitempty"`
 	Receivers []*receiverTestConfig `yaml:"receivers,omitempty"`
-	Template  string                `yaml:"template,omitempty"`
+	Template  []string              `yaml:"template,omitempty"`
 }
 
 // Required Config keys tests.
@@ -155,7 +155,7 @@ func TestMissingConfigKeys(t *testing.T) {
 	var config testConfig
 
 	// No receivers.
-	config = testConfig{Defaults: defaultsConfig, Receivers: []*receiverTestConfig{}, Template: "jiralert.tmpl"}
+	config = testConfig{Defaults: defaultsConfig, Receivers: []*receiverTestConfig{}, Template: []string{"jiralert.tmpl"}}
 	configErrorTestRunner(t, config, "no receivers defined")
 
 	// No template.
@@ -188,7 +188,7 @@ func TestRequiredReceiverConfigKeys(t *testing.T) {
 		config := testConfig{
 			Defaults:  defaultsConfig,
 			Receivers: []*receiverTestConfig{receiverConfig},
-			Template:  "jiratemplate.tmpl",
+			Template:  []string{"jiralert.tmpl"},
 		}
 		configErrorTestRunner(t, config, test.errorMessage)
 	}
@@ -237,7 +237,7 @@ func TestAuthKeysErrors(t *testing.T) {
 		config := testConfig{
 			Defaults:  defaultsConfig,
 			Receivers: []*receiverTestConfig{minimalReceiverTestConfig},
-			Template:  "jiralert.tmpl",
+			Template:  []string{"jiralert.tmpl"},
 		}
 
 		configErrorTestRunner(t, config, test.errorMessage)
@@ -294,7 +294,7 @@ func TestAuthKeysOverrides(t *testing.T) {
 		config := testConfig{
 			Defaults:  defaultsConfig,
 			Receivers: []*receiverTestConfig{receiverConfig},
-			Template:  "jiralert.tmpl",
+			Template:  []string{"jiralert.tmpl"},
 		}
 
 		yamlConfig, err := yaml.Marshal(&config)
@@ -353,7 +353,7 @@ func TestReceiverOverrides(t *testing.T) {
 		config := testConfig{
 			Defaults:  defaultsConfig,
 			Receivers: []*receiverTestConfig{receiverConfig},
-			Template:  "jiralert.tmpl",
+			Template:  []string{"jiralert.tmpl"},
 		}
 
 		yamlConfig, err := yaml.Marshal(&config)
@@ -455,7 +455,7 @@ func TestAutoResolveConfigReceiver(t *testing.T) {
 	config := testConfig{
 		Defaults:  defaultsConfig,
 		Receivers: []*receiverTestConfig{minimalReceiverTestConfig},
-		Template:  "jiralert.tmpl",
+		Template:  []string{"jiralert.tmpl"},
 	}
 
 	configErrorTestRunner(t, config, "bad config in receiver \"test\", 'auto_resolve' was defined with empty 'state' field")
@@ -473,7 +473,7 @@ func TestAutoResolveConfigDefault(t *testing.T) {
 	config := testConfig{
 		Defaults:  defaultsConfig,
 		Receivers: []*receiverTestConfig{minimalReceiverTestConfig},
-		Template:  "jiralert.tmpl",
+		Template:  []string{"jiralert.tmpl"},
 	}
 
 	configErrorTestRunner(t, config, "bad config in defaults section: state cannot be empty")
@@ -503,7 +503,7 @@ func TestStaticLabelsConfigMerge(t *testing.T) {
 		config := testConfig{
 			Defaults:  defaultsConfig,
 			Receivers: []*receiverTestConfig{receiverConfig},
-			Template:  "jiralert.tmpl",
+			Template:  []string{"jiralert.tmpl"},
 		}
 
 		yamlConfig, err := yaml.Marshal(&config)

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -41,6 +41,7 @@ var funcs = template.FuncMap{
 		return strings.Join(s, sep)
 	},
 	"match": regexp.MatchString,
+	"split": strings.Split,
 	"reReplaceAll": func(pattern, repl, text string) string {
 		re := regexp.MustCompile(pattern)
 		return re.ReplaceAllString(text, repl)
@@ -54,9 +55,9 @@ var funcs = template.FuncMap{
 }
 
 // LoadTemplate reads and parses all templates defined in the given file and constructs a jiralert.Template.
-func LoadTemplate(path string, logger log.Logger) (*Template, error) {
+func LoadTemplate(path []string, logger log.Logger) (*Template, error) {
 	level.Debug(logger).Log("msg", "loading templates", "path", path)
-	tmpl, err := template.New("").Option("missingkey=zero").Funcs(funcs).ParseFiles(path)
+	tmpl, err := template.New("").Option("missingkey=zero").Funcs(funcs).ParseFiles(path...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
for better clearness we use multiple templates, e.g. one template per jira custom field. as we use templates for mapping they get quite big and its handy to separate them. in additation added a split template handler

```
template:
  - jiralert_psk_key.tmpl
  - jiralert_insight_ia_key.tmpl
  - jiralert_Entwicklung.tmpl
```
