### PR TITLE
Make title in template return string

### DIFF
--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -38,7 +38,6 @@ var funcs = template.FuncMap{
 	"title": func(title string) string {
 		return cases.Title(language.AmericanEnglish).String(title)
 	},
-	// cases.Title,
 	// join is equal to strings.Join but inverts the argument order
 	// for easier pipelining in templates.
 	"join": func(sep string, s []string) string {

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 type Template struct {
@@ -34,7 +35,10 @@ type Template struct {
 var funcs = template.FuncMap{
 	"toUpper": strings.ToUpper,
 	"toLower": strings.ToLower,
-	"title":   cases.Title,
+	"title": func(title string) string {
+		return cases.Title(language.AmericanEnglish).String(title)
+	},
+	// cases.Title,
 	// join is equal to strings.Join but inverts the argument order
 	// for easier pipelining in templates.
 	"join": func(sep string, s []string) string {


### PR DESCRIPTION
Currently in template.go the title func returns a caser, which leads to an error mentioned in #186 
I have added a function that fixes said issue by using the caser and returning correct string