### PR TITLE
Added ability to update Priority of an existing ticket

### DIFF
--- a/cmd/jiralert/main.go
+++ b/cmd/jiralert/main.go
@@ -53,7 +53,7 @@ var (
 	updateDescription    = flag.Bool("update-description", true, "When false, jiralert does not update the description of the existing jira issue, even when changes are spotted.")
 	reopenTickets        = flag.Bool("reopen-tickets", true, "When false, jiralert does not reopen tickets.")
 	maxDescriptionLength = flag.Int("max-description-length", defaultMaxDescriptionLength, "Maximum length of Descriptions. Truncate to this size avoid server errors.")
-
+	updatePriority        = flag.Bool("update-priority", true, "When false, jiralert does not update the priority of the existing jira issue, even when changes are spotted.")
 	// Version is the build version, set by make to latest git tag/hash via `-ldflags "-X main.Version=$(VERSION)"`.
 	Version = "<local build>"
 )
@@ -126,7 +126,7 @@ func main() {
 			return
 		}
 
-		if retry, err := notify.NewReceiver(logger, conf, tmpl, client.Issue).Notify(&data, *hashJiraLabel, *updateSummary, *updateDescription, *reopenTickets, *maxDescriptionLength); err != nil {
+		if retry, err := notify.NewReceiver(logger, conf, tmpl, client.Issue).Notify(&data, *hashJiraLabel, *updateSummary, *updateDescription, *reopenTickets, *maxDescriptionLength, *updatePriority); err != nil {
 			var status int
 			if retry {
 				// Instruct Alertmanager to retry.

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -61,7 +61,7 @@ func NewReceiver(logger log.Logger, c *config.ReceiverConfig, t *template.Templa
 }
 
 // Notify manages JIRA issues based on alertmanager webhook notify message.
-func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool, updateSummary bool, updateDescription bool, reopenTickets bool, maxDescriptionLength int) (bool, error) {
+func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool, updateSummary bool, updateDescription bool, reopenTickets bool, maxDescriptionLength int, updatePriority bool) (bool, error) {
 	project, err := r.tmpl.Execute(r.conf.Project, data)
 	if err != nil {
 		return false, errors.Wrap(err, "generate project from template")
@@ -79,6 +79,11 @@ func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool, updateSum
 	issueSummary, err := r.tmpl.Execute(r.conf.Summary, data)
 	if err != nil {
 		return false, errors.Wrap(err, "generate summary from template")
+	}
+
+	issuePriority, err := r.tmpl.Execute(r.conf.Priority, data)
+	if err != nil {
+		return false, errors.Wrap(err, "generate priority from template")
 	}
 
 	issueDesc, err := r.tmpl.Execute(r.conf.Description, data)
@@ -103,7 +108,7 @@ func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool, updateSum
 				}
 			}
 		}
-
+		
 		if r.conf.UpdateInComment != nil && *r.conf.UpdateInComment {
 			numComments := 0
 			if issue.Fields.Comments != nil {
@@ -129,6 +134,16 @@ func (r *Receiver) Notify(data *alertmanager.Data, hashJiraLabel bool, updateSum
 		if updateDescription {
 			if issue.Fields.Description != issueDesc {
 				retry, err := r.updateDescription(issue.Key, issueDesc)
+				if err != nil {
+					return retry, err
+				}
+			}
+		}
+		
+		if updatePriority && issue.Fields.Priority != nil {
+			if issue.Fields.Priority.Name != issuePriority {
+				level.Debug(r.logger).Log("msg", "updating priority", "key", issue.Key, "new_priority", issuePriority)
+				retry, err := r.updatePriority(issue.Key, issuePriority)
 				if err != nil {
 					return retry, err
 				}
@@ -316,7 +331,7 @@ func (r *Receiver) search(projects []string, issueLabel string) (*jira.Issue, bo
 	projectList := "'" + strings.Join(projects, "', '") + "'"
 	query := fmt.Sprintf("project in(%s) and labels=%q order by resolutiondate desc", projectList, issueLabel)
 	options := &jira.SearchOptions{
-		Fields:     []string{"summary", "status", "resolution", "resolutiondate", "description", "comment"},
+		Fields:     []string{"summary", "priority", "status", "resolution", "resolutiondate", "description", "comment"},
 		MaxResults: 2,
 	}
 
@@ -475,4 +490,20 @@ func (r *Receiver) doTransition(issueKey string, transitionState string) (bool, 
 	}
 	return false, errors.Errorf("JIRA state %q does not exist or no transition possible for %s", transitionState, issueKey)
 
+}
+
+func (r *Receiver) updatePriority(issueKey string, priority string) (bool, error) {
+    level.Debug(r.logger).Log("msg", "updating issue with new priority", "key", issueKey, "priority", priority)
+    issueUpdate := &jira.Issue{
+        Key: issueKey,
+        Fields: &jira.IssueFields{
+            Priority: &jira.Priority{Name: priority},
+        },
+    }
+    issue, resp, err := r.client.UpdateWithOptions(issueUpdate, nil)
+    if err != nil {
+        return handleJiraErrResponse("Issue.UpdateWithOptions", resp, err, r.logger)
+    }
+    level.Debug(r.logger).Log("msg", "issue priority updated", "key", issue.Key, "id", issue.ID)
+	return false, nil
 }

--- a/pkg/notify/notify_test.go
+++ b/pkg/notify/notify_test.go
@@ -75,6 +75,12 @@ func (f *fakeJira) Search(jql string, options *jira.SearchOptions) ([]jira.Issue
 				issue.Fields.Status = &jira.Status{
 					StatusCategory: f.issuesByKey[key].Fields.Status.StatusCategory,
 				}
+			case "priority":
+                if f.issuesByKey[key].Fields.Priority != nil {
+                    issue.Fields.Priority = &jira.Priority{
+                        Name: f.issuesByKey[key].Fields.Priority.Name,
+                    }
+                }
 			}
 		}
 		issues = append(issues, issue)
@@ -128,6 +134,10 @@ func (f *fakeJira) UpdateWithOptions(old *jira.Issue, _ *jira.UpdateQueryOptions
 		issue.Fields.Summary = old.Fields.Summary
 	}
 
+	if old.Fields.Priority != nil {
+		issue.Fields.Priority = old.Fields.Priority
+	}
+
 	if old.Fields.Description != "" {
 		issue.Fields.Description = old.Fields.Description
 	}
@@ -169,6 +179,18 @@ func testReceiverConfig1() *config.ReceiverConfig {
 		ReopenState:       "reopened",
 		WontFixResolution: "won't-fix",
 	}
+}
+
+func testReceiverConfigWithPriority() *config.ReceiverConfig {
+    reopen := config.Duration(1 * time.Hour)
+    return &config.ReceiverConfig{
+        Project:           "abc",
+		Summary: 			`[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }}{{ if gt (len .CommonLabels) (len .GroupLabels) }} ({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}`,
+		ReopenDuration:    &reopen,
+        ReopenState:       "reopened",
+        WontFixResolution: "won't-fix",
+        Priority:          "Low",
+    }
 }
 
 func testReceiverConfig2() *config.ReceiverConfig {
@@ -686,6 +708,53 @@ func TestNotify_JIRAInteraction(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:        "update priority of an existing ticket",
+			inputConfig: testReceiverConfigWithPriority(),
+			initJira: func(t *testing.T) *fakeJira {
+				f := newTestFakeJira()
+				_, _, err := f.Create(&jira.Issue{
+					ID:  "1",
+					Key: "1",
+					Fields: &jira.IssueFields{
+						Project: jira.Project{Key: testReceiverConfigWithPriority().Project},
+						Labels:  []string{"JIRALERT{819ba5ecba4ea5946a8d17d285cb23f3bb6862e08bb602ab08fd231cd8e1a83a1d095b0208a661787e9035f0541817634df5a994d1b5d4200d6c68a7663c97f5}"},
+						Summary: "[FIRING:1] b d",
+						Priority: &jira.Priority{
+							Name: "Medium",
+						},
+						Unknowns: tcontainer.MarshalMap{},
+					},
+				})
+				require.NoError(t, err)
+				return f
+			},
+			inputAlert: &alertmanager.Data{
+				Alerts: alertmanager.Alerts{
+					{Status: alertmanager.AlertFiring},
+				},
+				Status:      alertmanager.AlertFiring,
+				GroupLabels: alertmanager.KV{"a": "b", "c": "d"},
+			},
+			expectedJiraIssues: map[string]*jira.Issue{
+				"1": {
+					ID:  "1",
+					Key: "1",
+					Fields: &jira.IssueFields{
+						Project: jira.Project{Key: testReceiverConfigWithPriority().Project},
+						Labels:  []string{"JIRALERT{819ba5ecba4ea5946a8d17d285cb23f3bb6862e08bb602ab08fd231cd8e1a83a1d095b0208a661787e9035f0541817634df5a994d1b5d4200d6c68a7663c97f5}"},
+						Summary: "[FIRING:1] b d",
+						Priority: &jira.Priority{
+							Name: "Low",
+						},
+						Status: &jira.Status{
+							StatusCategory: jira.StatusCategory{Key: "NotDone"},
+						},
+						Unknowns: tcontainer.MarshalMap{},
+					},
+				},
+			},
+		},
 	} {
 		if ok := t.Run(tcase.name, func(t *testing.T) {
 			fakeJira := tcase.initJira(t)
@@ -701,7 +770,7 @@ func TestNotify_JIRAInteraction(t *testing.T) {
 				return testNowTime
 			}
 
-			_, err := receiver.Notify(tcase.inputAlert, true, true, true, true, 32768)
+			_, err := receiver.Notify(tcase.inputAlert, true, true, true, true, 32768, true)
 			require.NoError(t, err)
 			require.Equal(t, tcase.expectedJiraIssues, fakeJira.issuesByKey)
 		}); !ok {


### PR DESCRIPTION
Hi Team, 

I’ve added a feature that allows updating the priority of an existing Jira ticket.
This enhancement ensures better flexibility in managing ticket importance post-creation.

Additionally, I’ve updated the relevant test cases to reflect this change. Looking forward to your review.
Thanks!