### PR TITLE
Deprecate the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # JIRAlert
-[![Build Status](https://github.com/prometheus-community/jiralert/workflows/test/badge.svg?branch=master)](https://github.com/prometheus-community/jiralert/actions?query=workflow%3Atest) 
-[![Go Report Card](https://goreportcard.com/badge/github.com/prometheus-community/jiralert)](https://goreportcard.com/report/github.com/prometheus-community/jiralert) 
-[![GoDoc](https://godoc.org/github.com/prometheus-community/jiralert?status.svg)](https://godoc.org/github.com/prometheus-community/jiralert)
-[![Slack](https://img.shields.io/badge/join%20slack-%23jiralert-brightgreen.svg)](https://slack.cncf.io/)
-[Prometheus Alertmanager](https://github.com/prometheus/alertmanager) webhook receiver for [JIRA](https://www.atlassian.com/software/jira).
+
+## Deprecated
+
+[!WARNING]
+**This project is deprecated in favor of [native Prometheus Alertmanager integration](https://prometheus.io/docs/alerting/latest/configuration/#jira_config)**
 
 ## Overview
 


### PR DESCRIPTION
Now that we have native Jira integration in the alertmanager this adapter service is obsolete.

Closes: https://github.com/prometheus-community/jiralert/issues/216